### PR TITLE
Ignore case sensitivity when mapping extension to plugins

### DIFF
--- a/OpenEmu/OESystemPlugin.m
+++ b/OpenEmu/OESystemPlugin.m
@@ -54,7 +54,9 @@ static NSMutableDictionary *pluginsBySystemIdentifiers = nil;
     NSArray *systems = [OEPlugin pluginsForType:self];
     for (OESystemPlugin *plugin in systems)
     {
-        if ([[plugin supportedTypeExtensions] containsObject:ext])
+        if ([[plugin supportedTypeExtensions] indexOfObjectPassingTest:^BOOL(NSString *obj, NSUInteger idx, BOOL *stop) {
+            return ([obj caseInsensitiveCompare:ext] == NSOrderedSame);
+        }] != NSNotFound)
             return plugin;
     }
     return nil;


### PR DESCRIPTION
Extensions should not be case-sensitive. Our library is willing to
overlook case sensitivity, so the game plugins should too.
