### PR TITLE
Initialize AEGameAudio.contexts before creating the graph

### DIFF
--- a/OpenEmu/OEGameAudio.m
+++ b/OpenEmu/OEGameAudio.m
@@ -91,8 +91,8 @@ OSStatus RenderCallback(void                       *in,
     if(self != nil)
     {
         gameCore = core;
+        contexts = [NSMutableArray array];
         [self createGraph];
-        self.contexts = [NSMutableArray array];
     }
     
     return self;


### PR DESCRIPTION
If the contexts array is nil, the OEGameAudioContext objects get
dealloc'd in the middle of -createGraph. This causes the helper app to
crash in the audio callback. Unfortunately, the contexts array was nil,
because it wasn't being initialized until after -createGraph was called.
Initialize it a bit earlier.
