### PR TITLE
Clean up warning in NSWindow+OECustomWindow

### DIFF
--- a/OpenEmu/NSWindow+OECustomWindow.m
+++ b/OpenEmu/NSWindow+OECustomWindow.m
@@ -81,11 +81,11 @@
 
     if(!drawingCustomWindow) return;
     // create drawing selector based on window class
-    NSString *winodwClassName = NSStringFromClass([window class]);
-    NSString *selectorName = [NSString stringWithFormat:@"draw%@ThemeRect:", winodwClassName];
+    NSString *windowClassName = NSStringFromClass([window class]);
+    NSString *selectorName = [NSString stringWithFormat:@"draw%@ThemeRect:", windowClassName];
     SEL customDrawingSelector = NSSelectorFromString(selectorName);
 
     // finally draw the custom theme frame
-    [self performSelector:customDrawingSelector withObject:[NSValue valueWithRect:dirtyRect]];    
+    ((void (*)(id, SEL, NSRect))objc_msgSend)(self, customDrawingSelector, dirtyRect);
 }
 @end


### PR DESCRIPTION
ARC doesn't like -performSelector:withObject: because it doesn't know
the memory semantics of the result value. Switch this code over to using
objc_msgSend() instead. While we're at it, make the called method take
an NSRect instead of an NSValue, since that was a hack for use with
-performSelector:withObject:. However, we're not actually implementing
this method anywhere in the project, so we don't need to update any
other methods.
