### PR TITLE
Delete -[OEDBSystem predicate] from DataSourceAdditions category

### DIFF
--- a/OpenEmu/OEDBDataSourceAdditions.m
+++ b/OpenEmu/OEDBDataSourceAdditions.m
@@ -205,11 +205,6 @@
     return NO;
 }
 
-- (NSPredicate *)predicate
-{
-    return [NSPredicate predicateWithFormat:@"system == %@", self];
-}
-
 @end
 
 #pragma mark -


### PR DESCRIPTION
The file OEDBDataSourceAdditions.m has two separate categories on
OEDBSystem, both of which define the same method -predicate. Delete the
implementation from one of the categories to fix a linker warning.
