### PR TITLE
Set Nestopia core aspect ratio.

### DIFF
--- a/Nestopia/NESGameCore.mm
+++ b/Nestopia/NESGameCore.mm
@@ -762,4 +762,9 @@ static int Heights[2] =
                                 : OESizeMake(Widths[0], Heights[0]);
 }
 
+- (OEIntSize)aspectSize
+{
+    return OESizeMake(256, 240);
+}
+
 @end


### PR DESCRIPTION
The NES aspect ratio is 256x240. The default game core aspect ratio,
4x3, results in horizontally stretched output.
