### PR TITLE
Fix Wii Remote Nunchuk button handling.

### DIFF
--- a/OpenEmu/OEWiimoteDeviceHandler.m
+++ b/OpenEmu/OEWiimoteDeviceHandler.m
@@ -645,8 +645,9 @@ enum {
     _latestButtonReports.nunchuck = data;
 
     _OEWiimoteIdentifierEnumerateUsingBlock(_OENunchuckButtonRange, ^(OEWiimoteButtonIdentifier identifier, NSUInteger usage, BOOL *stop) {
+        // Nunchuk uses 0 bit to mean pressed
         if(changes & identifier)
-            [self OE_dispatchButtonEventWithUsage:usage state:data & identifier timestamp:timestamp cookie:usage];
+            [self OE_dispatchButtonEventWithUsage:usage state:(data & identifier ? OEHIDEventStateOff : OEHIDEventStateOn) timestamp:timestamp cookie:usage];
     });
 }
 


### PR DESCRIPTION
The nunchuk button report uses 0 for pressed and 1 for released.

This came up in IRC the other night. CodingGuru should test this change, since he has the Nunchuk hardware and suggested the fix.
