### PR TITLE
Fixed duplicate events bug when binding controller inputs.

### DIFF
--- a/OpenEmu/OEDeviceManager.m
+++ b/OpenEmu/OEDeviceManager.m
@@ -186,7 +186,7 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
           */
          if(CGEventGetIntegerValueField([anEvent CGEvent], kCGEventSourceUnixProcessID) != 0)
          {
-             OEHIDEvent *event = [OEHIDEvent keyEventWithTimestamp:[anEvent timestamp] keyCode:[OEHIDEvent keyCodeForVirtualKey:[anEvent keyCode]] state:[anEvent type] == NSKeyDown cookie:0];
+             OEHIDEvent *event = [OEHIDEvent keyEventWithTimestamp:[anEvent timestamp] keyCode:[OEHIDEvent keyCodeForVirtualKey:[anEvent keyCode]] state:[anEvent type] == NSKeyDown cookie:NSNotFound];
 
              [NSApp postHIDEvent:event];
          }
@@ -221,7 +221,7 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
                  case kHIDUsage_KeyboardRightControl : keyMask = 0x2000; break;
              }
 
-             OEHIDEvent *event = [OEHIDEvent keyEventWithTimestamp:[anEvent timestamp] keyCode:keyCode state:!!([anEvent modifierFlags] & keyMask) cookie:0];
+             OEHIDEvent *event = [OEHIDEvent keyEventWithTimestamp:[anEvent timestamp] keyCode:keyCode state:!!([anEvent modifierFlags] & keyMask) cookie:NSNotFound];
 
              [NSApp postHIDEvent:event];
          }

--- a/OpenEmu/OENetServer.m
+++ b/OpenEmu/OENetServer.m
@@ -87,7 +87,7 @@
                                                  timestamp:[NSDate timeIntervalSinceReferenceDate]
                                               buttonNumber:b & 0x7F
                                                      state:b & 0x80 ? NSOnState : NSOffState
-                                                    cookie:0];
+                                                    cookie:NSNotFound];
     
     [[NSApplication sharedApplication] postHIDEvent:ret];
     [asyncSocket receiveWithTimeout:-1 tag:1];

--- a/OpenEmu/OEPrefControlsController.m
+++ b/OpenEmu/OEPrefControlsController.m
@@ -447,7 +447,7 @@ NSString *const OELastControlsDeviceTypeKey       = @"lastControlsDevice";
 
 - (BOOL)OE_shouldRegisterEvent:(OEHIDEvent *)anEvent;
 {
-    if([readingEvent hasOffState] || ([readingEvent cookie] != [anEvent cookie])) readingEvent = nil;
+    if([readingEvent hasOffState] || ![readingEvent isEqual:anEvent]) readingEvent = nil;
     
     if([self selectedKey] == nil && [self view] == [[[self view] window] firstResponder])
         [[[self view] window] makeFirstResponder:nil];
@@ -479,7 +479,7 @@ NSString *const OELastControlsDeviceTypeKey       = @"lastControlsDevice";
     // The event is the currently read event,
     // if it's off state, nil the reading event,
     // in either case, this event shouldn't be registered
-    if(readingEvent == anEvent)
+    if([readingEvent isEqual:anEvent])
     {
         if([anEvent hasOffState])
             readingEvent = nil;


### PR DESCRIPTION
Duplicate events can be dispatched if the user is running apps that emulate keyboard events (such as TextExpander), which can cause problems when the user tries to change their controller mappings. This commit fixes that by ignoring equivalent keyboard events.
