### PR TITLE
Resolve redundant events when using WII U Pro Controller

### DIFF
--- a/OpenEmu/OEWiimoteHIDDeviceHandler.m
+++ b/OpenEmu/OEWiimoteHIDDeviceHandler.m
@@ -496,8 +496,8 @@ enum {
 
 - (void)OE_handleDataReportData:(const uint8_t *)response length:(NSUInteger)length;
 {
-    if((response[1] != 0x3D) && (_expansionType != OEWiimoteExpansionTypeWiiUProController))
-		[self OE_parseWiimoteButtonData:(response[2] << 8 | response[3])];
+    if(response[1] != 0x3D && _expansionType != OEWiimoteExpansionTypeWiiUProController)
+        [self OE_parseWiimoteButtonData:(response[2] << 8 | response[3])];
 
     if(!_expansionPortEnabled || !_expansionPortAttached) return;
 


### PR DESCRIPTION
Tested with Pro Controller and Classic Controller on regular wiimote; resolves #488.
