### PR TITLE
Low-battery alert for Wiimotes

### DIFF
--- a/OpenEmu/OEDeviceHandler.h
+++ b/OpenEmu/OEDeviceHandler.h
@@ -62,4 +62,6 @@
 
 - (BOOL)isKeyboardDevice;
 
+extern NSString *const OEInputDeviceLowBatteryNotification;
+
 @end

--- a/OpenEmu/OEDeviceHandler.m
+++ b/OpenEmu/OEDeviceHandler.m
@@ -37,6 +37,8 @@
 #define NO __objc_no
 #endif
 
+NSString *const OEInputDeviceLowBatteryNotification = @"OEInputDeviceLowBatteryNotification";
+
 @interface OEHIDEvent ()
 - (BOOL)OE_setupEventWithDeviceHandler:(OEHIDDeviceHandler *)aDeviceHandler value:(IOHIDValueRef)aValue;
 @end

--- a/OpenEmu/OEDeviceManager.m
+++ b/OpenEmu/OEDeviceManager.m
@@ -283,23 +283,9 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
 {
     NSAssert(aDevice != NULL, @"Passing NULL device.");
     OEWiimoteHIDDeviceHandler *handler = [OEWiimoteHIDDeviceHandler deviceHandlerWithIOHIDDevice:aDevice];
-    NSUInteger existingWiimotes =
-    [[_deviceHandlers indexesOfObjectsPassingTest:
-      ^ BOOL (id obj, NSUInteger idx, BOOL *stop)
-      {
-          return [obj isKindOfClass:[OEWiimoteHIDDeviceHandler class]];
-      }] count];
 
     [handler setRumbleActivated:YES];
     [handler setExpansionPortEnabled:YES];
-
-    NSUInteger useLED = (existingWiimotes % 4) + 1;
-
-    [handler setIlluminatedLEDs:
-     (useLED == 1) ? OEWiimoteDeviceHandlerLED1 : 0 |
-     (useLED == 2) ? OEWiimoteDeviceHandlerLED2 : 0 |
-     (useLED == 3) ? OEWiimoteDeviceHandlerLED3 : 0 |
-     (useLED == 4) ? OEWiimoteDeviceHandlerLED4 : 0];
 
     if([handler connect])
     {
@@ -345,8 +331,8 @@ static const void * kOEBluetoothDevicePairSyncStyleKey = &kOEBluetoothDevicePair
 - (void)OE_addDeviceHandler:(OEDeviceHandler *)handler
 {
     NSUInteger idx = [_deviceHandlers indexOfObject:[NSNull null]];
-    //NSUInteger padNumber = (idx == NSNotFound ? [_deviceHandlers count] : idx) + 1;
-    //[handler setDeviceNumber:padNumber];
+    NSUInteger padNumber = (idx == NSNotFound ? [_deviceHandlers count] : idx) + 1;
+    [handler setDeviceNumber:padNumber];
 
     [self willChangeValueForKey:@"deviceHandlers"];
 

--- a/OpenEmu/OEGameViewController.h
+++ b/OpenEmu/OEGameViewController.h
@@ -25,6 +25,7 @@
  */
 
 #import <Cocoa/Cocoa.h>
+#import "OEDeviceHandler.h"
 
 extern NSString *const OEGameVolumeKey;
 extern NSString *const OEGameDefaultVideoFilterKey;
@@ -36,7 +37,6 @@ extern NSString *const OEForceCorePicker;
 extern NSString *const OEGameViewControllerEmulationWillFinishNotification;
 extern NSString *const OEGameViewControllerEmulationDidFinishNotification;
 extern NSString *const OEGameViewControllerROMKey;
-
 
 @class OEDBRom;
 @class OEDBGame;

--- a/OpenEmu/OEWiimoteHIDDeviceHandler.h
+++ b/OpenEmu/OEWiimoteHIDDeviceHandler.h
@@ -54,8 +54,7 @@ typedef enum {
 @interface OEWiimoteHIDDeviceHandler : OEHIDDeviceHandler
 
 @property(nonatomic) OEWiimoteDeviceHandlerLED illuminatedLEDs;
-
-@property(readonly) CGFloat batteryLevel;
+@property(readonly) BOOL lowBatteryWarning;
 
 @property(nonatomic, getter=isRumbleActivated)                 BOOL rumbleActivated;
 @property(nonatomic, getter=isExpansionPortEnabled)            BOOL expansionPortEnabled;


### PR DESCRIPTION
Initial support for Wii Remote battery handling in-emulation, as well as improved LED handling that combines number space across controller types.
