### PR TITLE
Added ability to use custom fonts for control labels in controller prefs

### DIFF
--- a/OpenEmu/OEControlsButtonSetupView.m
+++ b/OpenEmu/OEControlsButtonSetupView.m
@@ -366,9 +366,17 @@ static void *const _OEControlsSetupViewFrameSizeContext = (void *)&_OEControlsSe
                 else
                     [self OE_addGroupLabel:row];
             }
-            else if([row isKindOfClass:[NSDictionary class]])
+            else if([row isKindOfClass:[NSDictionary class]]) {
+                NSString *fontFamily = nil;
+
+                if([row objectForKey:OEControlListKeyFontFamilyKey] != nil) {
+                    fontFamily = [row objectForKey:OEControlListKeyFontFamilyKey];
+                }
+
                 [self OE_addButtonWithName:[row objectForKey:OEControlListKeyNameKey]
-                                     label:[[row objectForKey:OEControlListKeyLabelKey] stringByAppendingString:@":"]];
+                                     label:[[row objectForKey:OEControlListKeyLabelKey] stringByAppendingString:@":"]
+                                fontFamily:fontFamily];
+            }
         }
     }
 
@@ -398,6 +406,11 @@ static void *const _OEControlsSetupViewFrameSizeContext = (void *)&_OEControlsSe
 
 - (void)OE_addButtonWithName:(NSString *)aName label:(NSString *)aLabel;
 {
+    [self OE_addButtonWithName:aName label:aLabel fontFamily:nil];
+}
+
+- (void)OE_addButtonWithName:(NSString *)aName label:(NSString *)aLabel fontFamily:(NSString *)aFontFamily;
+{
     OEControlsKeyButton *button = [[OEControlsKeyButton alloc] initWithFrame:NSZeroRect];
     
     [button setTarget:target];
@@ -408,8 +421,13 @@ static void *const _OEControlsSetupViewFrameSizeContext = (void *)&_OEControlsSe
     
     [currentGroup addObject:button];
     
-    NSTextField     *labelField     = [[NSTextField alloc] initWithFrame:NSZeroRect];
-    NSTextFieldCell *labelFieldCell = [[OEControlsKeyLabelCell alloc] init];
+    NSTextField            *labelField     = [[NSTextField alloc] initWithFrame:NSZeroRect];
+    OEControlsKeyLabelCell *labelFieldCell = [[OEControlsKeyLabelCell alloc] init];
+    
+    if(aFontFamily != nil)
+    {
+        [labelFieldCell setFontFamily:aFontFamily];
+    }
     
     [labelField setCell:labelFieldCell];
     [labelField setStringValue:aLabel];

--- a/OpenEmu/OEControlsKeyLabelCell.h
+++ b/OpenEmu/OEControlsKeyLabelCell.h
@@ -28,4 +28,6 @@
 
 @interface OEControlsKeyLabelCell : OEAttributedTextFieldCell
 
+-(void)setFontFamily:(NSString *)fontFamily;
+
 @end

--- a/OpenEmu/OEControlsKeyLabelCell.m
+++ b/OpenEmu/OEControlsKeyLabelCell.m
@@ -32,7 +32,7 @@
 {
     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
     
-    NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSFontBoldTrait weight:9.0 size:11.0];
+    [self setFontFamily:@"Lucida Grande"];
     
     NSShadow *shadow = [[NSShadow alloc] init];
     [shadow setShadowBlurRadius:1.0];
@@ -40,9 +40,7 @@
     [shadow setShadowOffset:NSMakeSize(0, -1)];
     
     [attributes setObject:[NSColor colorWithDeviceWhite:0.0 alpha:1.0] forKey:NSForegroundColorAttributeName];
-    [attributes setObject:font forKey:NSFontAttributeName];
     [attributes setObject:shadow forKey:NSShadowAttributeName];
-    
     
     NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
     [style setAlignment:NSRightTextAlignment];
@@ -51,6 +49,15 @@
     self.textAttributes = attributes;
     
     [super setupAttributes];
+}
+
+-(void)setFontFamily:(NSString *)aFontFamily
+{
+    if(aFontFamily != nil)
+    {
+        NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:aFontFamily traits:NSFontBoldTrait weight:9.0 size:11.0];
+        [self setFont:font];
+    }
 }
 
 @end

--- a/OpenEmu/OESystemController.h
+++ b/OpenEmu/OESystemController.h
@@ -83,6 +83,7 @@ extern NSString *const OEAxisControlsKey;
 extern NSString *const OEControlListKey;
 extern NSString *const OEControlListKeyNameKey;
 extern NSString *const OEControlListKeyLabelKey;
+extern NSString *const OEControlListKeyFontFamilyKey;
 
 extern NSString *const OEControllerImageKey;       // NSString - file name of the controller image
 extern NSString *const OEControllerImageMaskKey;   // NSString - file name of the controller image mask

--- a/OpenEmu/OESystemController.m
+++ b/OpenEmu/OESystemController.m
@@ -59,36 +59,37 @@
 
 @end
 
-NSString *const OESettingValueKey            = @"OESettingValueKey";
-NSString *const OEHIDEventValueKey           = @"OEHIDEventValueKey";
-NSString *const OEHIDEventExtraValueKey      = @"OEHIDEventExtraValueKey";
-NSString *const OEKeyboardEventValueKey      = @"OEKeyboardEventValueKey";
-NSString *const OEControlsPreferenceKey      = @"OEControlsPreferenceKey";
-NSString *const OESystemIdentifier           = @"OESystemIdentifier";
-NSString *const OEProjectURLKey              = @"OEProjectURL";
-NSString *const OESystemName                 = @"OESystemName";
-NSString *const OENumberOfPlayersKey         = @"OENumberOfPlayersKey";
-NSString *const OEResponderClassKey          = @"OEResponderClassKey";
+NSString *const OESettingValueKey             = @"OESettingValueKey";
+NSString *const OEHIDEventValueKey            = @"OEHIDEventValueKey";
+NSString *const OEHIDEventExtraValueKey       = @"OEHIDEventExtraValueKey";
+NSString *const OEKeyboardEventValueKey       = @"OEKeyboardEventValueKey";
+NSString *const OEControlsPreferenceKey       = @"OEControlsPreferenceKey";
+NSString *const OESystemIdentifier            = @"OESystemIdentifier";
+NSString *const OEProjectURLKey               = @"OEProjectURL";
+NSString *const OESystemName                  = @"OESystemName";
+NSString *const OENumberOfPlayersKey          = @"OENumberOfPlayersKey";
+NSString *const OEResponderClassKey           = @"OEResponderClassKey";
 
-NSString *const OEKeyboardMappingsFileName   = @"Keyboard-Mappings";
-NSString *const OEControllerMappingsFileName = @"Controller-Mappings";
+NSString *const OEKeyboardMappingsFileName    = @"Keyboard-Mappings";
+NSString *const OEControllerMappingsFileName  = @"Controller-Mappings";
 
-NSString *const OESystemIconName             = @"OESystemIcon";
-NSString *const OEFileTypes                  = @"OEFileSuffixes";
+NSString *const OESystemIconName              = @"OESystemIcon";
+NSString *const OEFileTypes                   = @"OEFileSuffixes";
 
-NSString *const OESystemControlNamesKey      = @"OESystemControlNamesKey";
-NSString *const OEGenericControlNamesKey     = @"OEGenericControlNamesKey";
-NSString *const OEControlTypesKey            = @"OEControlTypesKey";
-NSString *const OEHatSwitchControlsKey       = @"OEHatSwitchControlsKey";
-NSString *const OEAxisControlsKey            = @"OEAxisControlsKey";
+NSString *const OESystemControlNamesKey       = @"OESystemControlNamesKey";
+NSString *const OEGenericControlNamesKey      = @"OEGenericControlNamesKey";
+NSString *const OEControlTypesKey             = @"OEControlTypesKey";
+NSString *const OEHatSwitchControlsKey        = @"OEHatSwitchControlsKey";
+NSString *const OEAxisControlsKey             = @"OEAxisControlsKey";
 
-NSString *const OEControlListKey             = @"OEControlListKey";
-NSString *const OEControlListKeyNameKey      = @"OEControlListKeyNameKey";
-NSString *const OEControlListKeyLabelKey     = @"OEControlListKeyLabelKey";
+NSString *const OEControlListKey              = @"OEControlListKey";
+NSString *const OEControlListKeyNameKey       = @"OEControlListKeyNameKey";
+NSString *const OEControlListKeyLabelKey      = @"OEControlListKeyLabelKey";
+NSString *const OEControlListKeyFontFamilyKey = @"OEControlListKeyFontFamilyKey";
 
-NSString *const OEControllerImageKey         = @"OEControllerImageKey";
-NSString *const OEControllerImageMaskKey     = @"OEControllerImageMaskKey";
-NSString *const OEControllerKeyPositionKey   = @"OEControllerKeyPositionKey";
+NSString *const OEControllerImageKey          = @"OEControllerImageKey";
+NSString *const OEControllerImageMaskKey      = @"OEControllerImageMaskKey";
+NSString *const OEControllerKeyPositionKey    = @"OEControllerKeyPositionKey";
 
 @implementation OESystemController
 @synthesize controllerKeyPositions, controllerImageMaskName, controllerImageName, controllerImage, controllerImageMask;

--- a/OpenEmu/PlayStation/PlayStation-Info.plist
+++ b/OpenEmu/PlayStation/PlayStation-Info.plist
@@ -41,6 +41,7 @@
 	<key>OEControlListKey</key>
 	<array>
 		<array>
+			<string>D Pad</string>
 			<dict>
 				<key>OEControlListKeyLabelKey</key>
 				<string>Up</string>
@@ -72,24 +73,32 @@
 				<string>△</string>
 				<key>OEControlListKeyNameKey</key>
 				<string>OEPSXButtonTriangle</string>
+				<key>OEControlListKeyFontFamilyKey</key>
+				<string>Apple LiGothic</string>
 			</dict>
 			<dict>
 				<key>OEControlListKeyLabelKey</key>
-				<string>◯</string>
+				<string>○</string>
 				<key>OEControlListKeyNameKey</key>
 				<string>OEPSXButtonCircle</string>
+				<key>OEControlListKeyFontFamilyKey</key>
+				<string>Apple LiGothic</string>
 			</dict>
 			<dict>
 				<key>OEControlListKeyLabelKey</key>
-				<string>✕</string>
+				<string>X</string>
 				<key>OEControlListKeyNameKey</key>
 				<string>OEPSXButtonCross</string>
+				<key>OEControlListKeyFontFamilyKey</key>
+				<string>Apple LiGothic</string>
 			</dict>
 			<dict>
 				<key>OEControlListKeyLabelKey</key>
-				<string>▢</string>
+				<string>□</string>
 				<key>OEControlListKeyNameKey</key>
 				<string>OEPSXButtonSquare</string>
+				<key>OEControlListKeyFontFamilyKey</key>
+				<string>Apple LiGothic</string>
 			</dict>
 		</array>
 		<array>


### PR DESCRIPTION
This is to make the playstation symbols look at little nicer in the controller prefs. I've used a font that is already included in OS X that renders the PSX symbols consistently. 
