### PR TITLE
Issue # 839: Support Game Boy ROMs with .sgb extension

### DIFF
--- a/OpenEmu/GameBoy/GameBoy-Info.plist
+++ b/OpenEmu/GameBoy/GameBoy-Info.plist
@@ -38,6 +38,7 @@
 	<array>
 		<string>gb</string>
 		<string>gbc</string>
+		<string>sgb</string>
 	</array>
 	<key>OEControlListKey</key>
 	<array>


### PR DESCRIPTION
OpenEmu/OpenEmu#839: Recognise .sgb files as Game Boy ROMs
