### PR TITLE
Fixed typo (incorrect case) in option text in Debug preferences

### DIFF
--- a/OpenEmu/OEPrefDebugController.xib
+++ b/OpenEmu/OEPrefDebugController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment defaultVersion="1070" identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="4514"/>
@@ -196,7 +196,7 @@
                 <button id="289" customClass="OEButton">
                     <rect key="frame" x="30" y="584" width="248" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" title="show collection view debug window" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="290" customClass="OEButtonCell">
+                    <buttonCell key="cell" type="check" title="Show collection view debug window" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="290" customClass="OEButtonCell">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>


### PR DESCRIPTION
'show collection view debug window' should be in sentence case to match the other options
