### PR TITLE
Issue # 848: Fix erroneous path returned when resetting library folder

### DIFF
--- a/OpenEmu/OEPrefLibraryController.m
+++ b/OpenEmu/OEPrefLibraryController.m
@@ -113,7 +113,7 @@
 - (IBAction)resetLibraryFolder:(id)sender
 {
     NSString *databasePath = [[NSUserDefaults standardUserDefaults] valueForKey:OEDefaultDatabasePathKey];
-    NSURL    *location     = [NSURL fileURLWithPath:databasePath isDirectory:YES];
+    NSURL    *location     = [NSURL fileURLWithPath:[databasePath stringByExpandingTildeInPath] isDirectory:YES];
 
     [self OE_changeROMFolderLocationTo:location];
 }


### PR DESCRIPTION
OpenEmu/OpenEmu#848: Tilde not being handled correctly when resetting library folder path, resulting in `/~/Library/Application Support/OpenEmu/Game Library`
