### PR TITLE
Wording improvements to remove collection confirmation dialogue 

### DIFF
--- a/OpenEmu/OESidebarController.m
+++ b/OpenEmu/OESidebarController.m
@@ -610,7 +610,7 @@ NSString * const OEMainViewMinWidth = @"mainViewMinWidth";
 
     if([item isEditableInSidebar] || [item isKindOfClass:[OEDBSmartCollection class]])
     {
-        NSString *msg = NSLocalizedString(@"Do you really want to remove this collection", @"");
+        NSString *msg = NSLocalizedString(@"Are you sure want to remove this collection?", @"");
         NSString *confirm = NSLocalizedString(@"Remove", @"");
         NSString *cancel = NSLocalizedString(@"Cancel", @"");
 


### PR DESCRIPTION
The confirmation dialogue that appears when you try to delete a collection had a missing question mark. It was also worded slightly differently from the dialogue that appears when you try to delete a game, so i made them more similar.
