### PR TITLE
Set Nearest Neighbor as default filter if the current one is not available

### DIFF
--- a/OpenEmu/OEGameControlsBar.m
+++ b/OpenEmu/OEGameControlsBar.m
@@ -323,7 +323,7 @@ NSString *const OEGameControlsBarFadeOutDelayKey        = @"fadeoutdelay";
                                 ? : [[NSUserDefaults standardUserDefaults] objectForKey:OEGameDefaultVideoFilterKey]);
 
     // Select the Default Filter if the current is not available (ie. deleted)
-    if (![_filterPlugins containsObject:selectedFilter])
+    if(![_filterPlugins containsObject:selectedFilter])
         selectedFilter = [[NSUserDefaults standardUserDefaults] objectForKey:OEGameDefaultVideoFilterKey];
 
     for(NSString *aName in _filterPlugins)

--- a/OpenEmu/OEGameView.m
+++ b/OpenEmu/OEGameView.m
@@ -948,7 +948,7 @@ static NSString *const _OEDefaultVideoFilterKey = @"videoFilter";
     OEGameShader *filter = [_filters objectForKey:_filterName];
 
     // Revert to the Default Filter if the current is not available (ie. deleted)
-    if (![_filters objectForKey:_filterName])
+    if(![_filters objectForKey:_filterName])
         _filterName = [[NSUserDefaults standardUserDefaults] objectForKey:_OEDefaultVideoFilterKey];
 
     [filter compileShaders];

--- a/OpenEmu/OEPrefGameplayController.m
+++ b/OpenEmu/OEPrefGameplayController.m
@@ -56,7 +56,7 @@
 	NSString *selectedFilterName = [sud objectForKey:OEGameDefaultVideoFilterKey];
 
     // Set Nearest Neighbor as default filter if the current one is not available (ie. deleted)
-    if (![filterPlugins containsObject:selectedFilterName])
+    if(![filterPlugins containsObject:selectedFilterName])
     {
         selectedFilterName = @"Nearest Neighbor";
         [sud setObject:@"Nearest Neighbor" forKey:OEGameDefaultVideoFilterKey];


### PR DESCRIPTION
Set Nearest Neighbor as default filter if the current one is not available (ie. has been deleted)

Both in Preferences/Global and per core (+ item selection in drop down list)
