### PR TITLE
Fixed background image name for retina

### DIFF
--- a/OpenEmu/OEBackgroundNoisePattern.m
+++ b/OpenEmu/OEBackgroundNoisePattern.m
@@ -79,7 +79,7 @@ void OEBackgroundHighResolutionNoisePatternCreate(void)
     dispatch_once(&OE_createHighResolutionPatternOnceToken, ^{
         // Create a pattern from the noise image and apply as the background color
         static const CGPatternCallbacks callbacks = {0, &OEBackgroundNoisePatternDrawInContext, &OEBackgroundNoisePatternRelease};
-        NSURL            *noiseImageURL = [[NSBundle mainBundle] URLForImageResource:@"noise@2x.png"];
+        NSURL            *noiseImageURL = [[NSBundle mainBundle] URLForImageResource:@"noise"];
         CGImageSourceRef  source        = CGImageSourceCreateWithURL((__bridge CFURLRef)noiseImageURL, NULL);
         OEBackgroundHighResolutionNoiseImageRef = CGImageSourceCreateImageAtIndex(source, 0, NULL);
 


### PR DESCRIPTION
The full image name (with the '@2x' suffix) here causes runtime error since Xcode combines artworks at different resolutions into one mulit-paged 'noise.tiff'  (COMBINE_HIDPI_IMAGES ).
