### PR TITLE
Avoid per-byte ObjC message when importing (~20% faster)

### DIFF
--- a/OpenEmu/NSFileManager+OEHashingAdditions.m
+++ b/OpenEmu/NSFileManager+OEHashingAdditions.m
@@ -27,8 +27,7 @@
 #import "NSFileManager+OEHashingAdditions.h"
 #import <CommonCrypto/CommonDigest.h>
 
-#define md5ChunkSize (1024 * 10)
-#define crc32ChunkSize 8
+#define HASH_READ_CHUNK_SIZE (1024 * 32)
 
 @implementation NSFileManager (OEHashingAdditions)
 
@@ -54,14 +53,15 @@
     do {
         @autoreleasepool
         {
-            NSData *data = [handle readDataOfLength:md5ChunkSize];
-            CC_MD5_Update(&md5Context, [data bytes], (CC_LONG)[data length]);
-            
+            NSData *data = [handle readDataOfLength:HASH_READ_CHUNK_SIZE];
             const unsigned char *bytes = [data bytes];
-            for(unsigned x = 0; x < [data length]; x++)
+            NSUInteger length = [data length];
+            CC_MD5_Update(&md5Context, bytes, (CC_LONG)length);
+            
+            for(unsigned x = 0; x < length; x++)
                 crcval = ((crcval >> 8) & 0x00ffffff) ^ crc32table[(crcval ^ (*(bytes + x))) & 0xff];
             
-            if(data == nil || [data length] < md5ChunkSize) break;
+            if(data == nil || length < HASH_READ_CHUNK_SIZE) break;
         }
     } while(YES);
     


### PR DESCRIPTION
This commit reduced import times of large files (500MB+) by about 20% for me. It will be less useful on spinning drives, but won't hurt, and it's a pretty straightforward optimization.

I also tried switching the NSFileHandle to an NSInputStream and reusing the same buffer rather than allocating a new NSData each time, but it was much more complicated code for a barely-measurable effect (< 5% improvement even for very large files), so I didn't do it.
## 

Rename md5ChunkSize to HASH_READ_CHUNK_SIZE and remove the unused crc32ChunkSize as the same read chunk is used for both hashes. Increase the chunk size from 10KB to 32KB. Optimize CRC32 inner loop to avoid calling the length message for each byte. Together these changes reduce total hash calculation time by about 20% when reading from an SSD.
