### PR TITLE
Fix issue #1128 "Leaking CGColor objects when calling IN_CGColorCreate i...

### DIFF
--- a/OpenEmu/INAppStoreWindow.h
+++ b/OpenEmu/INAppStoreWindow.h
@@ -1,83 +1,287 @@
 //
 //  INAppStoreWindow.h
 //
-//  Copyright 2011 Indragie Karunaratne. All rights reserved.
+//  Copyright 2011-2014 Indragie Karunaratne. All rights reserved.
 //
-//  Licensed under the BSD License <http://www.opensource.org/licenses/bsd-license>
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
-//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-//  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-//  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  Licensed under the BSD 2-clause License. See LICENSE file distributed in the source
+//  code of this project.
 //
 
 #import <Cocoa/Cocoa.h>
 
 #if __has_feature(objc_arc)
-#define INAppStoreWindowCopy nonatomic, strong
-#define INAppStoreWindowRetain nonatomic, strong
+#define INAppStoreWindowStrong strong
+#define INAppStoreWindowBridge __bridge
 #else
-#define INAppStoreWindowCopy nonatomic, copy
-#define INAppStoreWindowRetain nonatomic, retain
+#define INAppStoreWindowStrong retain
+#define INAppStoreWindowBridge
 #endif
 
-/** @class INTitlebarView
- Draws a default style Mac OS X title bar.
+@class INWindowButton;
+
+/**
+ Draws a default style OS X title bar.
  */
 @interface INTitlebarView : NSView
+
 @end
 
-/** @class INAppStoreWindow 
- Creates a window similar to the Mac App Store window, with centered traffic lights and an 
+/**
+ Creates a window similar to the Mac App Store window, with centered traffic lights and an
  enlarged title bar. This does not handle creating the toolbar.
  */
 @interface INAppStoreWindow : NSWindow
 
-/** The height of the title bar. By default, this is set to the standard title bar height. */
+/**
+ Prototype for a block used to implement custom drawing code for a window's title bar.
+ @param drawsAsMainWindow Whether the window should be drawn in main state.
+ @param drawingRect Drawing area of the window's title bar.
+ @param clippingPath Path to clip drawing according to window's rounded corners.
+ */
+typedef void (^INAppStoreWindowTitleBarDrawingBlock)(BOOL drawsAsMainWindow,
+													 CGRect drawingRect, CGPathRef clippingPath);
+
+/**
+ The height of the title bar. By default, this is set to the standard title bar height.
+ */
 @property (nonatomic) CGFloat titleBarHeight;
 
-/** The title bar view itself. Add subviews to this view that you want to show in the title bar 
- (e.g. buttons, a toolbar, etc.). This view can also be set if you want to use a different 
- styled title bar aside from the default one (textured, etc.). */
-@property (INAppStoreWindowRetain) NSView *titleBarView;
+/**
+ Container view for custom views added to the title bar.
+ 
+ Add subviews to this view that you want to show in the title bar (e.g. buttons, a toolbar, etc.).
+ This view can also be set if you want to use a different style title bar from the default one
+ (textured, etc.).
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSView *titleBarView;
 
-/** Set whether the fullscreen or traffic light buttons are horizontally centered */
+/**
+ Whether the fullscreen button is vertically centered.
+ */
 @property (nonatomic) BOOL centerFullScreenButton;
+
+/**
+ Whether the traffic light buttons are vertically centered.
+ */
 @property (nonatomic) BOOL centerTrafficLightButtons;
+
+/**
+ Whether the traffic light buttons are displayed in vertical orientation.
+ */
 @property (nonatomic) BOOL verticalTrafficLightButtons;
 
-/** If you want to hide the title bar in fullscreen mode, set this boolean to YES */
+/**
+ Whether the title is centered vertically.
+ */
+@property (nonatomic) BOOL verticallyCenterTitle;
+
+/**
+ Whether to hide the title bar in fullscreen mode.
+ */
 @property (nonatomic) BOOL hideTitleBarInFullScreen;
 
-/** Use this API to hide the baseline INAppStoreWindow draws between itself and the main window contents. */
+/**
+ Whether to display the baseline separator between the window's title bar and content area.
+ */
 @property (nonatomic) BOOL showsBaselineSeparator;
 
-/** Adjust the left and right padding of the trafficlight and fullscreen buttons */
+/**
+ Distance between the traffic light buttons and the left edge of the window.
+ */
 @property (nonatomic) CGFloat trafficLightButtonsLeftMargin;
+
+/**
+ * Distance between the traffic light buttons and the top edge of the window.
+ */
+@property (nonatomic) CGFloat trafficLightButtonsTopMargin;
+
+/**
+ Distance between the fullscreen button and the right edge of the window.
+ */
 @property (nonatomic) CGFloat fullScreenButtonRightMargin;
 
-/** The colors of the title bar background gradient and baseline separator, in main and non-main variants. */
-@property (INAppStoreWindowRetain) NSColor *titleBarStartColor;
-@property (INAppStoreWindowRetain) NSColor *titleBarEndColor;
-@property (INAppStoreWindowRetain) NSColor *baselineSeparatorColor;
-
-@property (INAppStoreWindowRetain) NSColor *inactiveTitleBarStartColor;
-@property (INAppStoreWindowRetain) NSColor *inactiveTitleBarEndColor;
-@property (INAppStoreWindowRetain) NSColor *inactiveBaselineSeparatorColor;
-
-
-/** So much logic and work has gone into this window subclass to achieve a custom title bar,
- it would be a shame to have to re-invent that just to change the look. So this block can be used
- to override the default Mac App Store style titlebar drawing with your own drawing code!
+/**
+ Distance between the fullscreen button and the top edge of the window.
  */
-typedef void (^INAppStoreWindowTitleBarDrawingBlock)(BOOL drawsAsMainWindow, 
-                                                     CGRect drawingRect, CGPathRef clippingPath);
-@property (INAppStoreWindowCopy) INAppStoreWindowTitleBarDrawingBlock titleBarDrawingBlock;
+@property (nonatomic) CGFloat fullScreenButtonTopMargin;
 
-- (void)setTitleBarDrawingBlock:(INAppStoreWindowTitleBarDrawingBlock)titleBarDrawingBlock;
+/**
+ Spacing between the traffic light buttons.
+ */
+@property (nonatomic) CGFloat trafficLightSeparation;
+
+/**
+ Number of points in any direction above which the window will be allowed to reposition.
+ A Higher value indicates coarser movements but much reduced CPU overhead. Defaults to 1.
+ */
+@property (nonatomic) CGFloat mouseDragDetectionThreshold;
+
+/**
+ Whether to show the window's title text. If \c YES, the title will be shown even if
+ \a titleBarDrawingBlock is set. To draw the title manually, set this property to \c NO
+ and draw the title using \a titleBarDrawingBlock.
+ */
+@property (nonatomic) BOOL showsTitle;
+
+/**
+ Whether to show the window's title text in fullscreen mode.
+ */
+@property (nonatomic) BOOL showsTitleInFullscreen;
+
+/**
+ Whether the window displays the document proxy icon (for document-based applications).
+ */
+@property (nonatomic) BOOL showsDocumentProxyIcon;
+
+/**
+ The button to use as the window's close button.
+ If this property is nil, the default button will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) INWindowButton *closeButton;
+
+/**
+ The button to use as the window's minimize button.
+ If this property is nil, the default button will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) INWindowButton *minimizeButton;
+
+/**
+ The button to use as the window's zoom button.
+ If this property is nil, the default button will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) INWindowButton *zoomButton;
+
+/**
+ The button to use as the window's fullscreen button.
+ If this property is nil, the default button will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) INWindowButton *fullScreenButton;
+
+/**
+ The font used to draw the window's title text.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSFont *titleFont;
+
+/**
+ Starting (top) color of the window's title bar gradient, when the window is main.
+ 
+ If this property is \c nil, the default color will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSColor *titleBarStartColor;
+
+/**
+ Ending (bottom) color of the window's title bar gradient, when the window is main.
+ 
+ If this property is \c nil, the default color will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSColor *titleBarEndColor;
+
+/**
+ Color of the separator line between a window's title bar and content area,
+ when the window is main.
+ 
+ If this property is \c nil, the default color will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSColor *baselineSeparatorColor;
+
+/**
+ Color of the window's title text, when the window is main.
+ 
+ If this property is \c nil, the default color will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSColor *titleTextColor;
+
+/**
+ Drop shadow under the window's title text, when the window is main.
+ 
+ If this property is \c nil, the default shadow will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSShadow *titleTextShadow;
+
+/**
+ Starting (top) color of the window's title bar gradient, when the window is not main.
+ 
+ If this property is \c nil, the default color will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSColor *inactiveTitleBarStartColor;
+
+/**
+ Ending (bottom) color of the window's title bar gradient, when the window is not main.
+ 
+ If this property is \c nil, the default color will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSColor *inactiveTitleBarEndColor;
+
+/**
+ Color of the separator line between a window's title bar and content area,
+ when the window is not main.
+ 
+ If this property is \c nil, the default color will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSColor *inactiveBaselineSeparatorColor;
+
+/**
+ Color of the window's title text, when the window is not main.
+ 
+ If this property is \c nil, the default color will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSColor *inactiveTitleTextColor;
+
+/**
+ Drop shadow under the window's title text, when the window is not main.
+ 
+ If this property is \c nil, the default shadow will be used.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSShadow *inactiveTitleTextShadow;
+
+/**
+ Block to override the drawing of the window title bar with a custom implementation.
+ */
+@property (nonatomic, copy) INAppStoreWindowTitleBarDrawingBlock titleBarDrawingBlock;
+
+/*!
+ Default system color of the starting (top) color of a window's title bar gradient.
+ @param drawsAsMainWindow \c YES to return the color used when the window is drawn in its main
+ state, \c NO to return the color used when the window is inactive.
+ 
+ @note This color may be an approximation and is subject to change at any time.
+ */
++ (NSColor *)defaultTitleBarStartColor:(BOOL)drawsAsMainWindow;
+
+/*!
+ Default system color of the ending (bottom) color of a window's title bar gradient.
+ @param drawsAsMainWindow \c YES to return the color used when the window is drawn in its main
+ state, \c NO to return the color used when the window is inactive.
+ 
+ @note This color may be an approximation and is subject to change at any time.
+ */
++ (NSColor *)defaultTitleBarEndColor:(BOOL)drawsAsMainWindow;
+
+/*!
+ Default system color of the separator line between a window's title bar and content area.
+ @param drawsAsMainWindow \c YES to return the color used when the window is drawn in its main
+ state, \c NO to return the color used when the window is inactive.
+ 
+ @note This color may be an approximation and is subject to change at any time.
+ */
++ (NSColor *)defaultBaselineSeparatorColor:(BOOL)drawsAsMainWindow;
+
+/*!
+ Default system color of a window's title text.
+ @param drawsAsMainWindow \c YES to return the color used when the window is drawn in its main
+ state, \c NO to return the color used when the window is inactive.
+ 
+ @note This color may be an approximation and is subject to change at any time.
+ */
++ (NSColor *)defaultTitleTextColor:(BOOL)drawsAsMainWindow;
+
+/**
+ Sets the height of the title bar. By default, this is set to the standard title bar height.
+ 
+ @param adjustWindowFrame Whether to adjust the window frame in response to the change in
+ the title bar height. By default, the window frame is adjusted when the title bar height
+ is changed.
+ */
+- (void)setTitleBarHeight:(CGFloat)titleBarHeight adjustWindowFrame:(BOOL)adjustWindowFrame;
 
 @end

--- a/OpenEmu/INAppStoreWindow.m
+++ b/OpenEmu/INAppStoreWindow.m
@@ -1,147 +1,146 @@
 //
-//  INAppStoreWindow.m
+//	INAppStoreWindow.m
 //
-//  Copyright 2011 Indragie Karunaratne. All rights reserved.
+//  Copyright 2011-2014 Indragie Karunaratne. All rights reserved.
 //
-//  Licensed under the BSD License <http://www.opensource.org/licenses/bsd-license>
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
-//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-//  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-//  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  Licensed under the BSD 2-clause License. See LICENSE file distributed in the source
+//  code of this project.
 //
 
 #import "INAppStoreWindow.h"
+#import "INWindowButton.h"
 
-#define IN_RUNNING_LION (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6)
-#define IN_COMPILING_LION __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+#import <objc/runtime.h>
 
-/** -----------------------------------------
- - There are 2 sets of colors, one for an active (key) state and one for an inactivate state
- - Each set contains 3 colors. 2 colors for the start and end of the title gradient, and another color to draw the separator line on the bottom
- - These colors are meant to mimic the color of the default titlebar (taken from OS X 10.6), but are subject
- to change at any time
- ----------------------------------------- **/
+#if __MAC_OS_X_VERSION_MAX_ALLOWED < 1070
+enum { NSWindowDocumentVersionsButton = 6, NSWindowFullScreenButton = 7 };
+enum { NSFullScreenWindowMask = 1 << 14 };
+extern NSString * const NSAccessibilityFullScreenButtonSubrole;
+extern NSString * const NSWindowWillEnterFullScreenNotification;
+extern NSString * const NSWindowDidEnterFullScreenNotification;
+extern NSString * const NSWindowWillExitFullScreenNotification;
+extern NSString * const NSWindowDidExitFullScreenNotification;
+extern NSString * const NSWindowWillEnterVersionBrowserNotification;
+extern NSString * const NSWindowDidEnterVersionBrowserNotification;
+extern NSString * const NSWindowWillExitVersionBrowserNotification;
+extern NSString * const NSWindowDidExitVersionBrowserNotification;
+#define NSAppKitVersionNumber10_7 1138
+#endif
 
-#define IN_COLOR_MAIN_START [NSColor colorWithDeviceWhite:0.659 alpha:1.0]
-#define IN_COLOR_MAIN_END [NSColor colorWithDeviceWhite:0.812 alpha:1.0]
-#define IN_COLOR_MAIN_BOTTOM [NSColor colorWithDeviceWhite:0.318 alpha:1.0]
-
-#define IN_COLOR_NOTMAIN_START [NSColor colorWithDeviceWhite:0.851 alpha:1.0]
-#define IN_COLOR_NOTMAIN_END [NSColor colorWithDeviceWhite:0.929 alpha:1.0]
-#define IN_COLOR_NOTMAIN_BOTTOM [NSColor colorWithDeviceWhite:0.600 alpha:1.0]
-
-/** Lion */
-
-#define IN_COLOR_MAIN_START_L [NSColor colorWithDeviceWhite:0.66 alpha:1.0]
-#define IN_COLOR_MAIN_END_L [NSColor colorWithDeviceWhite:0.9 alpha:1.0]
-#define IN_COLOR_MAIN_BOTTOM_L [NSColor colorWithDeviceWhite:0.408 alpha:1.0]
-
-#define IN_COLOR_NOTMAIN_START_L [NSColor colorWithDeviceWhite:0.878 alpha:1.0]
-#define IN_COLOR_NOTMAIN_END_L [NSColor colorWithDeviceWhite:0.976 alpha:1.0]
-#define IN_COLOR_NOTMAIN_BOTTOM_L [NSColor colorWithDeviceWhite:0.655 alpha:1.0]
+/** Values chosen to match the defaults in OS X 10.9, which may change in future versions **/
+const CGFloat INWindowDocumentIconButtonOriginY = 3.f;
+const CGFloat INWindowDocumentVersionsButtonOriginY = 2.f;
+const CGFloat INWindowDocumentVersionsDividerOriginY = 2.f;
 
 /** Corner clipping radius **/
 const CGFloat INCornerClipRadius = 4.0;
-const CGFloat INButtonTopOffset = 3.0;
 
+NS_INLINE bool INRunningLion() {
+	return floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_7;
+}
 
-@interface NSColor (INAdditions)
-- (CGColorRef)IN_CGColorCreate;
-@end
+NS_INLINE CGFloat INMidHeight(NSRect aRect) {
+	return (aRect.size.height * (CGFloat) 0.5);
+}
 
-@implementation NSColor (INAdditions)
-- (CGColorRef)IN_CGColorCreate
-{
-    if([self isEqualTo:[NSColor blackColor]]) return CGColorGetConstantColor(kCGColorBlack);
-    if([self isEqualTo:[NSColor whiteColor]]) return CGColorGetConstantColor(kCGColorWhite);
-    if([self isEqualTo:[NSColor clearColor]]) return CGColorGetConstantColor(kCGColorClear);
-    NSColor *rgbColor = [self colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
-    CGFloat components[4];
-    [rgbColor getComponents:components];
+CF_RETURNS_RETAINED
+NS_INLINE CGPathRef INCreateClippingPathWithRectAndRadius(NSRect rect, CGFloat radius) {
+	CGMutablePathRef path = CGPathCreateMutable();
+	CGPathMoveToPoint(path, NULL, NSMinX(rect), NSMinY(rect));
+	CGPathAddLineToPoint(path, NULL, NSMinX(rect), NSMaxY(rect) - radius);
+	CGPathAddArcToPoint(path, NULL, NSMinX(rect), NSMaxY(rect), NSMinX(rect) + radius, NSMaxY(rect), radius);
+	CGPathAddLineToPoint(path, NULL, NSMaxX(rect) - radius, NSMaxY(rect));
+	CGPathAddArcToPoint(path, NULL, NSMaxX(rect), NSMaxY(rect), NSMaxX(rect), NSMaxY(rect) - radius, radius);
+	CGPathAddLineToPoint(path, NULL, NSMaxX(rect), NSMinY(rect));
+	CGPathCloseSubpath(path);
+	return path;
+}
+
+NS_INLINE void INApplyClippingPath(CGPathRef path, CGContextRef ctx) {
+	CGContextAddPath(ctx, path);
+	CGContextClip(ctx);
+}
+
+NS_INLINE void INApplyClippingPathInCurrentContext(CGPathRef path) {
+	INApplyClippingPath(path, [[NSGraphicsContext currentContext] graphicsPort]);
+}
+
+CF_RETURNS_RETAINED
+NS_INLINE CGColorRef INCreateCGColorFromNSColor(NSColor *color) {
+	NSColor *rgbColor = [color colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+	CGFloat components[4];
+	[rgbColor getComponents:components];
     
-    CGColorSpaceRef theColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
-    CGColorRef theColor = CGColorCreate(theColorSpace, components);
-    CGColorSpaceRelease(theColorSpace);
-
-     #if !__has_feature(objc_arc)
-    return (CGColorRef)[(id)theColor autorelease];
-    #else
-    return theColor;
-    #endif
-}
-@end
-
-NS_INLINE CGFloat INMidHeight(NSRect aRect){
-    return (aRect.size.height * (CGFloat)0.5);
+	CGColorSpaceRef theColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
+	CGColorRef theColor = CGColorCreate(theColorSpace, components);
+	CGColorSpaceRelease(theColorSpace);
+	return theColor;
 }
 
-static inline CGPathRef createClippingPathWithRectAndRadius(NSRect rect, CGFloat radius)
-{
-    CGMutablePathRef path = CGPathCreateMutable();
-    CGPathMoveToPoint(path, NULL, NSMinX(rect), NSMinY(rect));
-    CGPathAddLineToPoint(path, NULL, NSMinX(rect), NSMaxY(rect)-radius);
-    CGPathAddArcToPoint(path, NULL, NSMinX(rect), NSMaxY(rect), NSMinX(rect)+radius, NSMaxY(rect), radius);
-    CGPathAddLineToPoint(path, NULL, NSMaxX(rect)-radius, NSMaxY(rect));
-    CGPathAddArcToPoint(path, NULL,  NSMaxX(rect), NSMaxY(rect), NSMaxX(rect), NSMaxY(rect)-radius, radius);
-    CGPathAddLineToPoint(path, NULL, NSMaxX(rect), NSMinY(rect));
-    CGPathCloseSubpath(path);
-    return path;
-}
-
-static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSColor *endingColor)
-{
-    CGFloat locations[2] = {0.0f, 1.0f, };
-    #if __has_feature(objc_arc)
-    CFArrayRef colors = (__bridge CFArrayRef)[NSArray arrayWithObjects:(__bridge id)[startingColor IN_CGColorCreate], (__bridge id)[endingColor IN_CGColorCreate], nil];
-    #else
-    CFArrayRef colors = (CFArrayRef)[NSArray arrayWithObjects:(id)[startingColor IN_CGColorCreate], (id)[endingColor IN_CGColorCreate], nil];
-    #endif
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    CGGradientRef gradient = CGGradientCreateWithColors(colorSpace, colors, locations);
-    CGColorSpaceRelease(colorSpace);
-    return gradient;
+CF_RETURNS_RETAINED
+NS_INLINE CGGradientRef INCreateGradientWithColors(NSColor *startingColor, NSColor *endingColor) {
+	CGFloat locations[2] = {0.0f, 1.0f,};
+	CGColorRef cgStartingColor = INCreateCGColorFromNSColor(startingColor);
+	CGColorRef cgEndingColor = INCreateCGColorFromNSColor(endingColor);
+	CFArrayRef colors = (INAppStoreWindowBridge CFArrayRef) [NSArray arrayWithObjects:(INAppStoreWindowBridge id) cgStartingColor, (INAppStoreWindowBridge id) cgEndingColor, nil];
+	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+	CGGradientRef gradient = CGGradientCreateWithColors(colorSpace, colors, locations);
+	CGColorSpaceRelease(colorSpace);
+	CGColorRelease(cgStartingColor);
+	CGColorRelease(cgEndingColor);
+	return gradient;
 }
 
 @interface INAppStoreWindowDelegateProxy : NSProxy <NSWindowDelegate>
-@property (nonatomic, assign) id<NSWindowDelegate> secondaryDelegate;
+@property (nonatomic, assign) id <NSWindowDelegate> secondaryDelegate;
 @end
 
 @implementation INAppStoreWindowDelegateProxy
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)selector
 {
-    NSMethodSignature *signature = [[self.secondaryDelegate class] instanceMethodSignatureForSelector:selector];
-    NSAssert(signature != nil, @"The method signature(%@) should not be nil becuase of the respondsToSelector: check", NSStringFromSelector(selector));
-    return signature;
+	NSMethodSignature *signature = [[self.secondaryDelegate class] instanceMethodSignatureForSelector:selector];
+	if (!signature) {
+		signature = [super methodSignatureForSelector:selector];
+	}
+	return signature;
 }
 
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
-    if ([self.secondaryDelegate respondsToSelector:aSelector]) {
-        return YES;
-    } else if (aSelector == @selector(window:willPositionSheet:usingRect:)) {
-        return YES;
-    }
-    return NO;
+	if ([self.secondaryDelegate respondsToSelector:aSelector]) {
+		return YES;
+	} else if (aSelector == @selector(window:willPositionSheet:usingRect:)) {
+		return YES;
+	}
+	return NO;
 }
 
 - (void)forwardInvocation:(NSInvocation *)anInvocation
 {
-    if ([self.secondaryDelegate respondsToSelector:[anInvocation selector]]) {
-        [anInvocation invokeWithTarget:self.secondaryDelegate];
-    }
+	if ([self.secondaryDelegate respondsToSelector:[anInvocation selector]]) {
+		[anInvocation invokeWithTarget:self.secondaryDelegate];
+	}
 }
 
 - (NSRect)window:(INAppStoreWindow *)window willPositionSheet:(NSWindow *)sheet usingRect:(NSRect)rect
 {
-    rect.origin.y = NSHeight(window.frame)-window.titleBarHeight;
-    return rect;
+	// Somehow the forwarding machinery doesn't handle this.
+	if ([self.secondaryDelegate respondsToSelector:_cmd]) {
+		return [self.secondaryDelegate window:window willPositionSheet:sheet usingRect:rect];
+	}
+	rect.origin.y = NSHeight(window.frame) - window.titleBarHeight;
+	return rect;
 }
+
+- (BOOL)isKindOfClass:(Class)aClass
+{
+	if (self.secondaryDelegate) {
+		return [self.secondaryDelegate isKindOfClass:aClass];
+	}
+	return NO;
+}
+
 @end
 
 @interface INAppStoreWindow ()
@@ -155,172 +154,316 @@ static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSC
 - (void)_displayWindowAndTitlebar;
 - (void)_hideTitleBarView:(BOOL)hidden;
 - (CGFloat)_defaultTrafficLightLeftMargin;
-- (CGFloat)_trafficLightSeparation;
+- (CGFloat)_defaultTrafficLightSeparation;
+- (NSRect)_contentViewFrame;
 @end
 
 @implementation INTitlebarView
 
 - (void)drawNoiseWithOpacity:(CGFloat)opacity
 {
-    static CGImageRef noiseImageRef = nil;
-    static dispatch_once_t oncePredicate;
-    dispatch_once(&oncePredicate, ^{
-        NSUInteger width = 124, height = width;
-        NSUInteger size = width*height;
-        char *rgba = (char *)malloc(size); srand(120);
-        for(NSUInteger i=0; i < size; ++i){rgba[i] = rand()%256;}
-        CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceGray();
-        CGContextRef bitmapContext =
-        CGBitmapContextCreate(rgba, width, height, 8, width, colorSpace, kCGImageAlphaNone);
-        CFRelease(colorSpace);
-        noiseImageRef = CGBitmapContextCreateImage(bitmapContext);
-        CFRelease(bitmapContext);
-        free(rgba);
-    });
+	static CGImageRef noiseImageRef = nil;
+	static dispatch_once_t oncePredicate;
+	dispatch_once(&oncePredicate, ^{
+		NSUInteger width = 124, height = width;
+		NSUInteger size = width * height;
+		char *rgba = (char *) malloc(size);
+		srand(120);
+		for (NSUInteger i = 0; i < size; ++i) {rgba[i] = (char) arc4random() % 256;}
+		CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceGray();
+		CGContextRef bitmapContext =
+        CGBitmapContextCreate(rgba, width, height, 8, width, colorSpace, (CGBitmapInfo) kCGImageAlphaNone);
+		CFRelease(colorSpace);
+		noiseImageRef = CGBitmapContextCreateImage(bitmapContext);
+		CFRelease(bitmapContext);
+		free(rgba);
+	});
+    
+	CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
+	CGContextSaveGState(context);
+	CGContextSetAlpha(context, opacity);
+	CGContextSetBlendMode(context, kCGBlendModeScreen);
+    
+	if ([[self window] respondsToSelector:@selector(backingScaleFactor)]) {
+		CGFloat scaleFactor = [[self window] backingScaleFactor];
+		CGContextScaleCTM(context, 1 / scaleFactor, 1 / scaleFactor);
+	}
+    
+	CGRect imageRect = (CGRect) {CGPointZero, (CGSize) {CGImageGetWidth(noiseImageRef), CGImageGetHeight(noiseImageRef)}};
+	CGContextDrawTiledImage(context, imageRect, noiseImageRef);
+	CGContextRestoreGState(context);
+}
 
-    CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
-    CGContextSaveGState(context);
-    CGContextSetAlpha(context, opacity);
-    CGContextSetBlendMode(context, kCGBlendModeScreen);
+- (void)drawWindowBackgroundGradient:(NSRect)drawingRect showsBaselineSeparator:(BOOL)showsBaselineSeparator clippingPath:(CGPathRef)clippingPath
+{
+	INAppStoreWindow *window = (INAppStoreWindow *) [self window];
+    
+	INApplyClippingPathInCurrentContext(clippingPath);
+    
+	if ((window.styleMask & NSTexturedBackgroundWindowMask) == NSTexturedBackgroundWindowMask) {
+		// If this is a textured window, we can draw the real background gradient and noise pattern
+		CGFloat contentBorderThickness = window.titleBarHeight;
+		if (((window.styleMask & NSFullScreenWindowMask) != NSFullScreenWindowMask)) {
+			contentBorderThickness -= window._minimumTitlebarHeight;
+		}
+        
+		[window setAutorecalculatesContentBorderThickness:NO forEdge:NSMaxYEdge];
+		[window setContentBorderThickness:contentBorderThickness forEdge:NSMaxYEdge];
+        
+		NSDrawWindowBackground(drawingRect);
+	} else {
+		// Not textured, we have to fake the background gradient and noise pattern
+		BOOL drawsAsMainWindow = ([window isMainWindow] && [[NSApplication sharedApplication] isActive]);
+        
+		NSColor *startColor = drawsAsMainWindow ? window.titleBarStartColor : window.inactiveTitleBarStartColor;
+		NSColor *endColor = drawsAsMainWindow ? window.titleBarEndColor : window.inactiveTitleBarEndColor;
+        
+		startColor = startColor ? startColor : [INAppStoreWindow defaultTitleBarStartColor:drawsAsMainWindow];
+		endColor = endColor ? endColor : [INAppStoreWindow defaultTitleBarEndColor:drawsAsMainWindow];
+        
+		CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];
+		CGGradientRef gradient = INCreateGradientWithColors(startColor, endColor);
+		CGContextDrawLinearGradient(context, gradient, CGPointMake(NSMidX(drawingRect), NSMinY(drawingRect)), CGPointMake(NSMidX(drawingRect), NSMaxY(drawingRect)), 0);
+		CGGradientRelease(gradient);
+        
+		if (INRunningLion() && drawsAsMainWindow) {
+			CGRect noiseRect = NSRectToCGRect(NSInsetRect(drawingRect, 1.0, 1.0));
+            
+			if (![window showsBaselineSeparator]) {
+				CGFloat separatorHeight = self.baselineSeparatorFrame.size.height;
+				noiseRect.origin.y -= separatorHeight;
+				noiseRect.size.height += separatorHeight;
+			}
+            
+			CGContextSaveGState(context);
+            
+			CGPathRef noiseClippingPath =
+            INCreateClippingPathWithRectAndRadius(noiseRect, INCornerClipRadius);
+			CGContextAddPath(context, noiseClippingPath);
+			CGContextClip(context);
+			CGPathRelease(noiseClippingPath);
+            
+			[self drawNoiseWithOpacity:0.1];
+            
+			CGContextRestoreGState(context);
+		}
+	}
+    
+	[self drawBaselineSeparator:self.baselineSeparatorFrame];
+}
 
-    if ( [[self window] respondsToSelector:@selector(backingScaleFactor)] ) {
-        CGFloat scaleFactor = [[self window] backingScaleFactor];
-        CGContextScaleCTM(context, 1/scaleFactor, 1/scaleFactor);
-    }
-
-    CGRect imageRect = (CGRect){CGPointZero, CGImageGetWidth(noiseImageRef), CGImageGetHeight(noiseImageRef)};
-    CGContextDrawTiledImage(context, imageRect, noiseImageRef);
-    CGContextRestoreGState(context);
+- (void)drawBaselineSeparator:(NSRect)separatorFrame
+{
+	INAppStoreWindow *window = (INAppStoreWindow *) [self window];
+	BOOL drawsAsMainWindow = ([window isMainWindow] && [[NSApplication sharedApplication] isActive]);
+    
+	NSColor *bottomColor = drawsAsMainWindow ? window.baselineSeparatorColor : window.inactiveBaselineSeparatorColor;
+    
+	bottomColor = bottomColor ? bottomColor : [INAppStoreWindow defaultBaselineSeparatorColor:drawsAsMainWindow];
+    
+	[bottomColor set];
+	NSRectFill(separatorFrame);
+    
+	if (INRunningLion()) {
+		separatorFrame.origin.y += separatorFrame.size.height;
+		separatorFrame.size.height = 1.0;
+		[[NSColor colorWithDeviceWhite:1.0 alpha:0.12] setFill];
+		[[NSBezierPath bezierPathWithRect:separatorFrame] fill];
+	}
 }
 
 - (void)drawRect:(NSRect)dirtyRect
 {
-    INAppStoreWindow *window = (INAppStoreWindow *)[self window];
-    BOOL drawsAsMainWindow = ([window isMainWindow] && [[NSApplication sharedApplication] isActive]);
+	INAppStoreWindow *window = (INAppStoreWindow *) [self window];
+	BOOL drawsAsMainWindow = ([window isMainWindow] && [[NSApplication sharedApplication] isActive]);
     
-    NSRect drawingRect = [self bounds];
-    if ( window.titleBarDrawingBlock ) {
-        CGPathRef clippingPath = createClippingPathWithRectAndRadius(drawingRect, INCornerClipRadius);
-        window.titleBarDrawingBlock(drawsAsMainWindow, NSRectToCGRect(drawingRect), clippingPath);
-        CGPathRelease(clippingPath);
-    } else {
-        CGContextRef context = [[NSGraphicsContext currentContext] graphicsPort];        
+	// Start by filling the title bar area with black in fullscreen mode to match native apps
+	// Custom title bar drawing blocks can simply override this by not applying the clipping path
+	if ((([window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask)) {
+		[[NSColor blackColor] setFill];
+		[[NSBezierPath bezierPathWithRect:self.bounds] fill];
+	}
+    
+	CGPathRef clippingPath = NULL;
+	NSRect drawingRect = [self bounds];
+    
+	if (window.titleBarDrawingBlock) {
+		clippingPath = INCreateClippingPathWithRectAndRadius(drawingRect, INCornerClipRadius);
+		window.titleBarDrawingBlock(drawsAsMainWindow, NSRectToCGRect(drawingRect), clippingPath);
+	} else {
+		// There's a thin whitish line between the darker gray window border line
+		// and the gray noise textured gradient; preserve that when drawing a native title bar
+		NSRect clippingRect = drawingRect;
+		clippingRect.size.height -= 1;
+		clippingPath = INCreateClippingPathWithRectAndRadius(clippingRect, INCornerClipRadius);
         
-        NSColor *startColor = drawsAsMainWindow ? window.titleBarStartColor : window.inactiveTitleBarStartColor;
-        NSColor *endColor = drawsAsMainWindow ? window.titleBarEndColor : window.titleBarEndColor;
+		[self drawWindowBackgroundGradient:drawingRect showsBaselineSeparator:window.showsBaselineSeparator clippingPath:clippingPath];
+	}
+    
+	CGPathRelease(clippingPath);
+    
+	if ([window showsTitle] && (([window styleMask] & NSFullScreenWindowMask) == 0 || window.showsTitleInFullscreen)) {
+		NSRect titleTextRect;
+		NSDictionary *titleTextStyles = nil;
+		[self getTitleFrame:&titleTextRect textAttributes:&titleTextStyles forWindow:window];
         
-        if (IN_RUNNING_LION) {
-            startColor = startColor ?: (drawsAsMainWindow ? IN_COLOR_MAIN_START_L : IN_COLOR_NOTMAIN_START_L);
-            endColor = endColor ?: (drawsAsMainWindow ? IN_COLOR_MAIN_END_L : IN_COLOR_NOTMAIN_END_L);
-        } else {
-            startColor = startColor ?: (drawsAsMainWindow ? IN_COLOR_MAIN_START : IN_COLOR_NOTMAIN_START);
-            endColor = endColor ?: (drawsAsMainWindow ? IN_COLOR_MAIN_END : IN_COLOR_NOTMAIN_END);
-        }
+		if (window.verticallyCenterTitle) {
+			titleTextRect.origin.y = floor(NSMidY(drawingRect) - (NSHeight(titleTextRect) / 2.f) + 1);
+		}
         
-        NSRect clippingRect = drawingRect;
-        #if IN_COMPILING_LION
-        if((([window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask)){
-            [[NSColor blackColor] setFill];
-            [[NSBezierPath bezierPathWithRect:self.bounds] fill];
-        }
-        #endif
-        clippingRect.size.height -= 1;        
-        CGPathRef clippingPath = createClippingPathWithRectAndRadius(clippingRect, INCornerClipRadius);
-        CGContextAddPath(context, clippingPath);
-        CGContextClip(context);
-        CGPathRelease(clippingPath);
-        
-        CGGradientRef gradient = createGradientWithColors(startColor, endColor);
-        CGContextDrawLinearGradient(context, gradient, CGPointMake(NSMidX(drawingRect), NSMinY(drawingRect)), 
-                                    CGPointMake(NSMidX(drawingRect), NSMaxY(drawingRect)), 0);
-        CGGradientRelease(gradient);
-
-        if ([window showsBaselineSeparator]) {
-            NSColor *bottomColor = drawsAsMainWindow ? window.baselineSeparatorColor : window.inactiveBaselineSeparatorColor;
-            
-            if (IN_RUNNING_LION) {
-                bottomColor = bottomColor ? bottomColor : drawsAsMainWindow ? IN_COLOR_MAIN_BOTTOM_L : IN_COLOR_NOTMAIN_BOTTOM_L;
-            } else {
-                bottomColor = bottomColor ? bottomColor : drawsAsMainWindow ? IN_COLOR_MAIN_BOTTOM : IN_COLOR_NOTMAIN_BOTTOM;
-            }
-            
-            NSRect bottomRect = NSMakeRect(0.0, NSMinY(drawingRect), NSWidth(drawingRect), 1.0);
-            [bottomColor set];
-            NSRectFill(bottomRect);
-            
-            if (IN_RUNNING_LION) {
-              bottomRect.origin.y += 1.0;
-              [[NSColor colorWithDeviceWhite:1.0 alpha:0.12] setFill];
-              [[NSBezierPath bezierPathWithRect:bottomRect] fill];
-            }
-        }
-        
-        if (IN_RUNNING_LION && drawsAsMainWindow) {
-            CGRect noiseRect = NSInsetRect(drawingRect, 1.0, 1.0);
-            
-            if (![window showsBaselineSeparator]) {
-                noiseRect.origin.y    -= 1.0;
-                noiseRect.size.height += 1.0;
-            }
-            
-            CGPathRef noiseClippingPath = 
-            createClippingPathWithRectAndRadius(noiseRect, INCornerClipRadius);
-            CGContextAddPath(context, noiseClippingPath);
-            CGContextClip(context);
-            CGPathRelease(noiseClippingPath);
-            
-            [self drawNoiseWithOpacity:0.1];
-        }        
-    }
+		[window.title drawInRect:titleTextRect withAttributes:titleTextStyles];
+	}
 }
 
-- (void)mouseUp:(NSEvent *)theEvent 
+- (NSRect)baselineSeparatorFrame
 {
-    if ([theEvent clickCount] == 2) {
-        // Get settings from "System Preferences" >  "Appearance" > "Double-click on windows title bar to minimize"
-        NSString *const MDAppleMiniaturizeOnDoubleClickKey = @"AppleMiniaturizeOnDoubleClick";
-        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-        BOOL shouldMiniaturize = [[userDefaults objectForKey:MDAppleMiniaturizeOnDoubleClickKey] boolValue];
-        if (shouldMiniaturize) {
-            [[self window] miniaturize:self];
-        }
-    }
+	const NSRect windowBounds = self.bounds;
+	return NSMakeRect(0, NSMinY(windowBounds), NSWidth(windowBounds), 1);
+}
+
+- (void)getTitleFrame:(out NSRect *)frame textAttributes:(out NSDictionary **)attributes forWindow:(in INAppStoreWindow *)window
+{
+	BOOL drawsAsMainWindow = ([window isMainWindow] && [[NSApplication sharedApplication] isActive]);
+    
+	NSShadow *titleTextShadow = drawsAsMainWindow ? window.titleTextShadow : window.inactiveTitleTextShadow;
+	if (titleTextShadow == nil) {
+		titleTextShadow = [[NSShadow alloc] init];
+		titleTextShadow.shadowBlurRadius = 0.0;
+		titleTextShadow.shadowOffset = NSMakeSize(0, -1);
+		titleTextShadow.shadowColor = [NSColor colorWithDeviceWhite:1.0 alpha:0.5];
+#if !__has_feature(objc_arc)
+		[titleTextShadow autorelease];
+#endif
+	}
+    
+	NSColor *titleTextColor = drawsAsMainWindow ? window.titleTextColor : window.inactiveTitleTextColor;
+	titleTextColor = titleTextColor ? titleTextColor : [INAppStoreWindow defaultTitleTextColor:drawsAsMainWindow];
+    
+	NSFont *titleFont = window.titleFont ?: [NSFont titleBarFontOfSize:[NSFont systemFontSizeForControlSize:NSRegularControlSize]];
+    
+	NSDictionary *titleTextStyles = [NSDictionary dictionaryWithObjectsAndKeys:
+                                     titleFont, NSFontAttributeName,
+                                     titleTextColor, NSForegroundColorAttributeName,
+                                     titleTextShadow, NSShadowAttributeName,
+                                     nil];
+	NSSize titleSize = [window.title sizeWithAttributes:titleTextStyles];
+	NSRect titleTextRect;
+	titleTextRect.size = titleSize;
+    
+	NSButton *docIconButton = [window standardWindowButton:NSWindowDocumentIconButton];
+	NSButton *versionsButton = [window standardWindowButton:NSWindowDocumentVersionsButton];
+	if (docIconButton) {
+		NSRect docIconButtonFrame = [self convertRect:docIconButton.frame fromView:docIconButton.superview];
+		titleTextRect.origin.x = NSMaxX(docIconButtonFrame) + 4.0;
+		titleTextRect.origin.y = NSMidY(docIconButtonFrame) - titleSize.height / 2 + 1;
+	}
+	else if (versionsButton) {
+		NSRect versionsButtonFrame = [self convertRect:versionsButton.frame fromView:versionsButton.superview];
+		titleTextRect.origin.x = NSMinX(versionsButtonFrame) - titleSize.width - 1;
+        
+		NSDocument *document = (NSDocument *) [(NSWindowController *) self.window.windowController document];
+		if ([document hasUnautosavedChanges] || [document isDocumentEdited]) {
+			titleTextRect.origin.x -= 20;
+		}
+	}
+	else {
+		titleTextRect.origin.x = NSMidX(self.bounds) - titleSize.width / 2;
+	}
+	titleTextRect.origin.y = NSMaxY(self.bounds) - titleSize.height - 2.0;
+    
+	if (frame) {
+		*frame = titleTextRect;
+	}
+	if (attributes) {
+		*attributes = titleTextStyles;
+	}
+}
+
+- (void)mouseUp:(NSEvent *)theEvent
+{
+	if ([theEvent clickCount] == 2) {
+		// Get settings from "System Preferences" >	 "Appearance" > "Double-click on windows title bar to minimize"
+		NSString *const MDAppleMiniaturizeOnDoubleClickKey = @"AppleMiniaturizeOnDoubleClick";
+		NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+		BOOL shouldMiniaturize = [[userDefaults objectForKey:MDAppleMiniaturizeOnDoubleClickKey] boolValue];
+		if (shouldMiniaturize) {
+			[[self window] performMiniaturize:self];
+		}
+	}
 }
 
 @end
 
 @interface INTitlebarContainer : NSView
+@property (nonatomic) CGFloat mouseDragDetectionThreshold;
 @end
 
 @implementation INTitlebarContainer
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+	self = [super initWithFrame:frameRect];
+	if (self) {
+		_mouseDragDetectionThreshold = 1;
+	}
+	return self;
+}
+
 - (void)mouseDragged:(NSEvent *)theEvent
 {
-    NSWindow *window = [self window];
-    NSPoint where =  [window convertBaseToScreen:[theEvent locationInWindow]];
+	NSWindow *window = [self window];
+	if ([window isMovableByWindowBackground] || ([window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask) {
+		[super mouseDragged:theEvent];
+		return;
+	}
     
-    if ([window isMovableByWindowBackground]) {
-        [super mouseDragged: theEvent];
-        return;
-    }
-    
-    NSPoint origin = [window frame].origin;
-    while ((theEvent = [NSApp nextEventMatchingMask:NSLeftMouseDownMask | NSLeftMouseDraggedMask | NSLeftMouseUpMask untilDate:[NSDate distantFuture] inMode:NSEventTrackingRunLoopMode dequeue:YES]) && ([theEvent type] != NSLeftMouseUp)) {
-        @autoreleasepool {
-            NSPoint now = [window convertBaseToScreen:[theEvent locationInWindow]];
-            origin.x += now.x - where.x;
-            origin.y += now.y - where.y;
-            [window setFrameOrigin:origin];
-            where = now;
-        }
-    }
+	NSPoint where = [window convertBaseToScreen:[theEvent locationInWindow]];
+	NSPoint origin = [window frame].origin;
+	CGFloat deltaX = 0.0;
+	CGFloat deltaY = 0.0;
+	while ((theEvent = [NSApp nextEventMatchingMask:NSLeftMouseDownMask | NSLeftMouseDraggedMask | NSLeftMouseUpMask untilDate:[NSDate distantFuture] inMode:NSEventTrackingRunLoopMode dequeue:YES]) && ([theEvent type] != NSLeftMouseUp)) {
+		@autoreleasepool {
+			NSPoint now = [window convertBaseToScreen:[theEvent locationInWindow]];
+			deltaX += now.x - where.x;
+			deltaY += now.y - where.y;
+			if (fabs(deltaX) >= _mouseDragDetectionThreshold || fabs(deltaY) >= _mouseDragDetectionThreshold) {
+				// This part is only called if drag occurs on container view!
+				origin.x += deltaX;
+				origin.y += deltaY;
+				[window setFrameOrigin:origin];
+				deltaX = 0.0;
+				deltaY = 0.0;
+			}
+			where = now; // this should be inside above if but doing that results in jittering while moving the window...
+		}
+	}
 }
 @end
 
-@implementation INAppStoreWindow{
-    CGFloat _cachedTitleBarHeight;  
-    BOOL _setFullScreenButtonRightMargin;
-    INAppStoreWindowDelegateProxy *_delegateProxy;
-    INTitlebarContainer *_titleBarContainer;
+@interface INAppStoreWindowContentView : NSView
+@end
+
+@implementation INAppStoreWindowContentView
+
+- (void)setFrame:(NSRect)frameRect
+{
+	frameRect = [(INAppStoreWindow *) self.window _contentViewFrame];
+	[super setFrame:frameRect];
+}
+
+- (void)setFrameSize:(NSSize)newSize
+{
+	newSize = [(INAppStoreWindow *) self.window _contentViewFrame].size;
+	[super setFrameSize:newSize];
+}
+
+@end
+
+@implementation INAppStoreWindow {
+	CGFloat _cachedTitleBarHeight;
+	BOOL _setFullScreenButtonRightMargin;
+	BOOL _preventWindowFrameChange;
+	INAppStoreWindowDelegateProxy *_delegateProxy;
+	INTitlebarContainer *_titleBarContainer;
 }
 
 @synthesize titleBarView = _titleBarView;
@@ -339,24 +482,33 @@ static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSC
 @synthesize inactiveTitleBarStartColor = _inactiveTitleBarStartColor;
 @synthesize inactiveTitleBarEndColor = _inactiveTitleBarEndColor;
 @synthesize inactiveBaselineSeparatorColor = _inactiveBaselineSeparatorColor;
+@synthesize showsDocumentProxyIcon = _showsDocumentProxyIcon;
 
 #pragma mark -
 #pragma mark Initialization
 
 - (id)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)aStyle backing:(NSBackingStoreType)bufferingType defer:(BOOL)flag
 {
-    if ((self = [super initWithContentRect:contentRect styleMask:aStyle backing:bufferingType defer:flag])) {
-        [self _doInitialWindowSetup];
-    }
-    return self;
+	if ((self = [super initWithContentRect:contentRect styleMask:aStyle backing:bufferingType defer:flag])) {
+		[self _doInitialWindowSetup];
+	}
+	return self;
 }
 
 - (id)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)aStyle backing:(NSBackingStoreType)bufferingType defer:(BOOL)flag screen:(NSScreen *)screen
 {
-    if ((self = [super initWithContentRect:contentRect styleMask:aStyle backing:bufferingType defer:flag screen:screen])) {
-        [self _doInitialWindowSetup];
-    }
-    return self;
+	if ((self = [super initWithContentRect:contentRect styleMask:aStyle backing:bufferingType defer:flag screen:screen])) {
+		[self _doInitialWindowSetup];
+	}
+	return self;
+}
+
+- (void)setRepresentedURL:(NSURL *)url
+{
+	[super setRepresentedURL:url];
+	if (_showsDocumentProxyIcon == NO) {
+		[[self standardWindowButton:NSWindowDocumentIconButton] setImage:nil];
+	}
 }
 
 #pragma mark -
@@ -364,13 +516,17 @@ static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSC
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-//    [self setDelegate:nil];
-    #if !__has_feature(objc_arc)
-//    [_delegateProxy release];
-    [_titleBarView release];
-    [super dealloc];    
-    #endif
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+    //	  [self setDelegate:nil];
+#if !__has_feature(objc_arc)
+    //	  [_delegateProxy release];
+	[_titleBarView release];
+	[_closeButton release];
+	[_minimizeButton release];
+	[_zoomButton release];
+	[_fullScreenButton release];
+	[super dealloc];
+#endif
 }
 
 #pragma mark -
@@ -378,48 +534,66 @@ static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSC
 
 - (void)becomeKeyWindow
 {
-    [super becomeKeyWindow];
-    [self _updateTitlebarView];
-    [self _layoutTrafficLightsAndContent];
-    [self _setupTrafficLightsTrackingArea];
+	[super becomeKeyWindow];
+	[self _updateTitlebarView];
+	[self _layoutTrafficLightsAndContent];
+	[self _setupTrafficLightsTrackingArea];
 }
 
 - (void)resignKeyWindow
 {
-    [super resignKeyWindow];
-    [self _updateTitlebarView];
-    [self _layoutTrafficLightsAndContent];
+	[super resignKeyWindow];
+	[self _updateTitlebarView];
+	[self _layoutTrafficLightsAndContent];
 }
 
 - (void)becomeMainWindow
 {
-    [super becomeMainWindow];
-    [self _updateTitlebarView];
+	[super becomeMainWindow];
+	[self _updateTitlebarView];
 }
 
 - (void)resignMainWindow
 {
-    [super resignMainWindow];
-    [self _updateTitlebarView];
+	[super resignMainWindow];
+	[self _updateTitlebarView];
 }
 
 - (void)setContentView:(NSView *)aView
 {
-    [super setContentView:aView];
-
-#if IN_COMPILING_LION
-    if (IN_RUNNING_LION)
-        [self layoutIfNeeded];
-#endif
+	// Remove performance-optimized content view class when changing content views
+	NSView *oldView = [self contentView];
+	if (oldView && object_getClass(oldView) == [INAppStoreWindowContentView class]) {
+		object_setClass(oldView, [NSView class]);
+	}
     
-    [self _repositionContentView];
+	[super setContentView:aView];
+    
+	// Swap in performance-optimized content view class
+	if (aView && object_getClass(aView) == [NSView class]) {
+		object_setClass(aView, [INAppStoreWindowContentView class]);
+	}
+    
+	[self _repositionContentView];
 }
 
 - (void)setTitle:(NSString *)aString
 {
-    [super setTitle:aString];
-    [self _layoutTrafficLightsAndContent];
-    [self _displayWindowAndTitlebar];
+	[super setTitle:aString];
+	[self _layoutTrafficLightsAndContent];
+	[self _displayWindowAndTitlebar];
+}
+
+- (void)setMaxSize:(NSSize)size
+{
+	[super setMaxSize:size];
+	[self _layoutTrafficLightsAndContent];
+}
+
+- (void)setMinSize:(NSSize)size
+{
+	[super setMinSize:size];
+	[self _layoutTrafficLightsAndContent];
 }
 
 #pragma mark -
@@ -427,120 +601,276 @@ static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSC
 
 - (void)setTitleBarView:(NSView *)newTitleBarView
 {
-    if ((_titleBarView != newTitleBarView) && newTitleBarView) {
-        [_titleBarView removeFromSuperview];
-        #if __has_feature(objc_arc)
-        _titleBarView = newTitleBarView;
-        #else
-        [_titleBarView release];
-        _titleBarView = [newTitleBarView retain];
-        #endif
-        [_titleBarView setFrame:[_titleBarContainer bounds]];
-        [_titleBarView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-        [_titleBarContainer addSubview:_titleBarView];
-    }
+	if ((_titleBarView != newTitleBarView) && newTitleBarView) {
+		[_titleBarView removeFromSuperview];
+#if __has_feature(objc_arc)
+		_titleBarView = newTitleBarView;
+#else
+		[_titleBarView release];
+		_titleBarView = [newTitleBarView retain];
+#endif
+		[_titleBarView setFrame:[_titleBarContainer bounds]];
+		[_titleBarView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+		[_titleBarContainer addSubview:_titleBarView];
+	}
 }
 
 - (NSView *)titleBarView
 {
-    return _titleBarView;
+	return _titleBarView;
 }
 
-- (void)setTitleBarHeight:(CGFloat)newTitleBarHeight 
+- (void)setTitleBarHeight:(CGFloat)newTitleBarHeight
 {
-    if (_titleBarHeight != newTitleBarHeight) {
-        _cachedTitleBarHeight = newTitleBarHeight;
-        _titleBarHeight = _cachedTitleBarHeight;
-        [self _layoutTrafficLightsAndContent];
-        [self _displayWindowAndTitlebar];
-    }
+	[self setTitleBarHeight:newTitleBarHeight adjustWindowFrame:YES];
+}
+
+- (void)setTitleBarHeight:(CGFloat)newTitleBarHeight adjustWindowFrame:(BOOL)adjustWindowFrame
+{
+	if (_titleBarHeight != newTitleBarHeight) {
+		NSRect windowFrame = self.frame;
+		if (adjustWindowFrame)
+		{
+			windowFrame.origin.y -= newTitleBarHeight - _titleBarHeight;
+			windowFrame.size.height += newTitleBarHeight - _titleBarHeight;
+		}
+        
+		_cachedTitleBarHeight = newTitleBarHeight;
+		_titleBarHeight = _cachedTitleBarHeight;
+        
+		[self setFrame:windowFrame display:YES];
+        
+		[self _layoutTrafficLightsAndContent];
+		[self _displayWindowAndTitlebar];
+        
+		if ((self.styleMask & NSTexturedBackgroundWindowMask) == NSTexturedBackgroundWindowMask)
+			[self.contentView displayIfNeeded];
+	}
 }
 
 - (CGFloat)titleBarHeight
 {
-    return _titleBarHeight;
+	return _titleBarHeight;
 }
 
 - (void)setShowsBaselineSeparator:(BOOL)showsBaselineSeparator
 {
-    if (_showsBaselineSeparator != showsBaselineSeparator) {
-        _showsBaselineSeparator = showsBaselineSeparator;
-        [self.titleBarView setNeedsDisplay:YES];
-    }
+	if (_showsBaselineSeparator != showsBaselineSeparator) {
+		_showsBaselineSeparator = showsBaselineSeparator;
+		[self.titleBarView setNeedsDisplay:YES];
+	}
 }
 
 - (BOOL)showsBaselineSeparator
 {
-    return _showsBaselineSeparator;
+	return _showsBaselineSeparator;
 }
 
 - (void)setTrafficLightButtonsLeftMargin:(CGFloat)newTrafficLightButtonsLeftMargin
 {
-    if (_trafficLightButtonsLeftMargin != newTrafficLightButtonsLeftMargin) {
-        _trafficLightButtonsLeftMargin = newTrafficLightButtonsLeftMargin;
-        [self _layoutTrafficLightsAndContent];
-        [self _displayWindowAndTitlebar];
-        [self _setupTrafficLightsTrackingArea];
-    }
+	if (_trafficLightButtonsLeftMargin != newTrafficLightButtonsLeftMargin) {
+		_trafficLightButtonsLeftMargin = newTrafficLightButtonsLeftMargin;
+		[self _layoutTrafficLightsAndContent];
+		[self _displayWindowAndTitlebar];
+		[self _setupTrafficLightsTrackingArea];
+	}
 }
 
 - (CGFloat)trafficLightButtonsLeftMargin
 {
-    return _trafficLightButtonsLeftMargin;
+	return _trafficLightButtonsLeftMargin;
 }
 
 
 - (void)setFullScreenButtonRightMargin:(CGFloat)newFullScreenButtonRightMargin
 {
-    if (_fullScreenButtonRightMargin != newFullScreenButtonRightMargin) {
-        _setFullScreenButtonRightMargin = YES;
-        _fullScreenButtonRightMargin = newFullScreenButtonRightMargin;
-        [self _layoutTrafficLightsAndContent];
-        [self _displayWindowAndTitlebar];
-    }
+	if (_fullScreenButtonRightMargin != newFullScreenButtonRightMargin) {
+		_setFullScreenButtonRightMargin = YES;
+		_fullScreenButtonRightMargin = newFullScreenButtonRightMargin;
+		[self _layoutTrafficLightsAndContent];
+		[self _displayWindowAndTitlebar];
+	}
 }
 
 - (CGFloat)fullScreenButtonRightMargin
 {
-    return _fullScreenButtonRightMargin;
+	return _fullScreenButtonRightMargin;
 }
 
-- (void)setCenterFullScreenButton:(BOOL)centerFullScreenButton{
-    if( _centerFullScreenButton != centerFullScreenButton ) {
-        _centerFullScreenButton = centerFullScreenButton;
-        [self _layoutTrafficLightsAndContent];
-    }
+- (void)setShowsTitle:(BOOL)showsTitle
+{
+	if (_showsTitle != showsTitle) {
+		_showsTitle = showsTitle;
+		[self _displayWindowAndTitlebar];
+	}
+}
+
+- (void)setShowsDocumentProxyIcon:(BOOL)showsDocumentProxyIcon
+{
+	if (_showsDocumentProxyIcon != showsDocumentProxyIcon) {
+		_showsDocumentProxyIcon = showsDocumentProxyIcon;
+		[self _displayWindowAndTitlebar];
+	}
+}
+
+- (void)setCenterFullScreenButton:(BOOL)centerFullScreenButton
+{
+	if (_centerFullScreenButton != centerFullScreenButton) {
+		_centerFullScreenButton = centerFullScreenButton;
+		[self _layoutTrafficLightsAndContent];
+	}
 }
 
 - (void)setCenterTrafficLightButtons:(BOOL)centerTrafficLightButtons
 {
-    if ( _centerTrafficLightButtons != centerTrafficLightButtons ) {
-        _centerTrafficLightButtons = centerTrafficLightButtons;
-        [self _layoutTrafficLightsAndContent];
-        [self _setupTrafficLightsTrackingArea];
-    }
+	if (_centerTrafficLightButtons != centerTrafficLightButtons) {
+		_centerTrafficLightButtons = centerTrafficLightButtons;
+		[self _layoutTrafficLightsAndContent];
+		[self _setupTrafficLightsTrackingArea];
+	}
 }
-
 
 - (void)setVerticalTrafficLightButtons:(BOOL)verticalTrafficLightButtons
 {
-    if ( _verticalTrafficLightButtons != verticalTrafficLightButtons ) {
-        _verticalTrafficLightButtons = verticalTrafficLightButtons;
-        [self _layoutTrafficLightsAndContent];
-        [self _setupTrafficLightsTrackingArea];
-    }
+	if (_verticalTrafficLightButtons != verticalTrafficLightButtons) {
+		_verticalTrafficLightButtons = verticalTrafficLightButtons;
+		[self _layoutTrafficLightsAndContent];
+		[self _setupTrafficLightsTrackingArea];
+	}
 }
 
-- (void)setDelegate:(id<NSWindowDelegate>)anObject
+- (void)setVerticallyCenterTitle:(BOOL)verticallyCenterTitle
 {
-    [_delegateProxy setSecondaryDelegate:anObject];
-    [super setDelegate:nil];
-    [super setDelegate:_delegateProxy];    
+	if (_verticallyCenterTitle != verticallyCenterTitle) {
+		_verticallyCenterTitle = verticallyCenterTitle;
+		[self _displayWindowAndTitlebar];
+	}
 }
 
-- (id<NSWindowDelegate>)delegate
+- (void)setTrafficLightSeparation:(CGFloat)trafficLightSeparation
 {
-    return [_delegateProxy secondaryDelegate];
+	if (_trafficLightSeparation != trafficLightSeparation) {
+		_trafficLightSeparation = trafficLightSeparation;
+		[self _layoutTrafficLightsAndContent];
+		[self _setupTrafficLightsTrackingArea];
+	}
+}
+
+- (void)setMouseDragDetectionThreshold:(CGFloat)mouseDragDetectionThreshold
+{
+	_titleBarContainer.mouseDragDetectionThreshold = mouseDragDetectionThreshold;
+}
+
+- (CGFloat)mouseDragDetectionThreshold
+{
+	return _titleBarContainer.mouseDragDetectionThreshold;
+}
+
+- (void)setDelegate:(id <NSWindowDelegate>)anObject
+{
+	[_delegateProxy setSecondaryDelegate:anObject];
+	[super setDelegate:nil];
+	[super setDelegate:_delegateProxy];
+}
+
+- (id <NSWindowDelegate>)delegate
+{
+	return [_delegateProxy secondaryDelegate];
+}
+
+- (void)setCloseButton:(INWindowButton *)closeButton
+{
+	if (_closeButton != closeButton) {
+		[_closeButton removeFromSuperview];
+		_closeButton = closeButton;
+		if (_closeButton) {
+			_closeButton.target = self;
+			_closeButton.action = @selector(performClose:);
+			[_closeButton setFrameOrigin:[[self standardWindowButton:NSWindowCloseButton] frame].origin];
+			[_closeButton.cell accessibilitySetOverrideValue:NSAccessibilityCloseButtonSubrole forAttribute:NSAccessibilitySubroleAttribute];
+			[_closeButton.cell accessibilitySetOverrideValue:NSAccessibilityRoleDescription(NSAccessibilityButtonRole, NSAccessibilityCloseButtonSubrole) forAttribute:NSAccessibilityRoleDescriptionAttribute];
+			[[self themeFrameView] addSubview:_closeButton];
+		}
+	}
+}
+
+- (void)setMinimizeButton:(INWindowButton *)minimizeButton
+{
+	if (_minimizeButton != minimizeButton) {
+		[_minimizeButton removeFromSuperview];
+		_minimizeButton = minimizeButton;
+		if (_minimizeButton) {
+			_minimizeButton.target = self;
+			_minimizeButton.action = @selector(performMiniaturize:);
+			[_minimizeButton setFrameOrigin:[[self standardWindowButton:NSWindowMiniaturizeButton] frame].origin];
+			[_minimizeButton.cell accessibilitySetOverrideValue:NSAccessibilityMinimizeButtonSubrole forAttribute:NSAccessibilitySubroleAttribute];
+			[_minimizeButton.cell accessibilitySetOverrideValue:NSAccessibilityRoleDescription(NSAccessibilityButtonRole, NSAccessibilityMinimizeButtonSubrole) forAttribute:NSAccessibilityRoleDescriptionAttribute];
+			[[self themeFrameView] addSubview:_minimizeButton];
+		}
+	}
+}
+
+- (void)setZoomButton:(INWindowButton *)zoomButton
+{
+	if (_zoomButton != zoomButton) {
+		[_zoomButton removeFromSuperview];
+		_zoomButton = zoomButton;
+		if (_zoomButton) {
+			_zoomButton.target = self;
+			_zoomButton.action = @selector(performZoom:);
+			[_zoomButton setFrameOrigin:[[self standardWindowButton:NSWindowZoomButton] frame].origin];
+			[_zoomButton.cell accessibilitySetOverrideValue:NSAccessibilityZoomButtonSubrole forAttribute:NSAccessibilitySubroleAttribute];
+			[_zoomButton.cell accessibilitySetOverrideValue:NSAccessibilityRoleDescription(NSAccessibilityButtonRole, NSAccessibilityZoomButtonSubrole) forAttribute:NSAccessibilityRoleDescriptionAttribute];
+			[[self themeFrameView] addSubview:_zoomButton];
+		}
+	}
+}
+
+- (void)setFullScreenButton:(INWindowButton *)fullScreenButton
+{
+	if (_fullScreenButton != fullScreenButton) {
+		[_fullScreenButton removeFromSuperview];
+		_fullScreenButton = fullScreenButton;
+		if (_fullScreenButton) {
+			_fullScreenButton.target = self;
+			_fullScreenButton.action = @selector(toggleFullScreen:);
+			[_fullScreenButton setFrameOrigin:[[self standardWindowButton:NSWindowFullScreenButton] frame].origin];
+			[_fullScreenButton.cell accessibilitySetOverrideValue:NSAccessibilityFullScreenButtonSubrole forAttribute:NSAccessibilitySubroleAttribute];
+			[_fullScreenButton.cell accessibilitySetOverrideValue:NSAccessibilityRoleDescription(NSAccessibilityButtonRole, NSAccessibilityFullScreenButtonSubrole) forAttribute:NSAccessibilityRoleDescriptionAttribute];
+			[[self themeFrameView] addSubview:_fullScreenButton];
+		}
+	}
+}
+
+- (void)setStyleMask:(NSUInteger)styleMask
+{
+	_preventWindowFrameChange = YES;
+    
+	// Prevent drawing artifacts when turning off NSTexturedBackgroundWindowMask before
+	// exiting from full screen and then resizing the title bar; the problem is that internally
+	// the content border is still set to the previous value, which confuses the system
+	if (((self.styleMask & NSTexturedBackgroundWindowMask) == NSTexturedBackgroundWindowMask) &&
+        ((styleMask & NSTexturedBackgroundWindowMask) != NSTexturedBackgroundWindowMask)) {
+		[self setContentBorderThickness:0 forEdge:NSMaxYEdge];
+		[self setAutorecalculatesContentBorderThickness:YES forEdge:NSMaxYEdge];
+	}
+    
+	[super setStyleMask:styleMask];
+	[self _displayWindowAndTitlebar];
+	[self.contentView display]; // force display, the view doesn't think it needs it, but it does
+	_preventWindowFrameChange = NO;
+}
+
+- (void)setFrame:(NSRect)frameRect display:(BOOL)flag
+{
+	if (!_preventWindowFrameChange)
+		[super setFrame:frameRect display:flag];
+}
+
+- (void)setFrame:(NSRect)frameRect display:(BOOL)displayFlag animate:(BOOL)animateFlag
+{
+	if (!_preventWindowFrameChange)
+		[super setFrame:frameRect display:displayFlag animate:animateFlag];
 }
 
 #pragma mark -
@@ -548,233 +878,362 @@ static inline CGGradientRef createGradientWithColors(NSColor *startingColor, NSC
 
 - (void)_doInitialWindowSetup
 {
-    _showsBaselineSeparator = YES;
-    _centerTrafficLightButtons = YES;
-    _titleBarHeight = [self _minimumTitlebarHeight];
-    _trafficLightButtonsLeftMargin = [self _defaultTrafficLightLeftMargin];
-    _delegateProxy = [INAppStoreWindowDelegateProxy alloc];
-    [super setDelegate:_delegateProxy];
+	_showsBaselineSeparator = YES;
+	_centerTrafficLightButtons = YES;
+	_titleBarHeight = [self _minimumTitlebarHeight];
+	_cachedTitleBarHeight = _titleBarHeight;
+	_trafficLightButtonsLeftMargin = [self _defaultTrafficLightLeftMargin];
+	_delegateProxy = [INAppStoreWindowDelegateProxy alloc];
+	_trafficLightButtonsTopMargin = 3.f;
+	_fullScreenButtonTopMargin = 3.f;
+	_trafficLightSeparation = [self _defaultTrafficLightSeparation];
+	[super setDelegate:_delegateProxy];
     
-    /** -----------------------------------------
-     - The window automatically does layout every time its moved or resized, which means that the traffic lights and content view get reset at the original positions, so we need to put them back in place
-     - NSWindow is hardcoded to redraw the traffic lights in a specific rect, so when they are moved down, only part of the buttons get redrawn, causing graphical artifacts. Therefore, the window must be force redrawn every time it becomes key/resigns key
-     ----------------------------------------- **/
-    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    [nc addObserver:self selector:@selector(_layoutTrafficLightsAndContent) name:NSWindowDidResizeNotification object:self];
-    [nc addObserver:self selector:@selector(_layoutTrafficLightsAndContent) name:NSWindowDidMoveNotification object:self];
-    [nc addObserver:self selector:@selector(_layoutTrafficLightsAndContent) name:NSWindowDidEndSheetNotification object:self];
+	/** -----------------------------------------
+	 - The window automatically does layout every time its moved or resized, which means that the traffic lights and content view get reset at the original positions, so we need to put them back in place
+	 - NSWindow is hardcoded to redraw the traffic lights in a specific rect, so when they are moved down, only part of the buttons get redrawn, causing graphical artifacts. Therefore, the window must be force redrawn every time it becomes key/resigns key
+	 ----------------------------------------- **/
+	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+	[nc addObserver:self selector:@selector(_layoutTrafficLightsAndContent) name:NSWindowDidResizeNotification object:self];
+	[nc addObserver:self selector:@selector(_layoutTrafficLightsAndContent) name:NSWindowDidMoveNotification object:self];
+	[nc addObserver:self selector:@selector(_layoutTrafficLightsAndContent) name:NSWindowDidEndSheetNotification object:self];
+    
+	[nc addObserver:self selector:@selector(_updateTitlebarView) name:NSApplicationDidBecomeActiveNotification object:nil];
+	[nc addObserver:self selector:@selector(_updateTitlebarView) name:NSApplicationDidResignActiveNotification object:nil];
+	if (INRunningLion()) {
+		[nc addObserver:self selector:@selector(windowDidExitFullScreen:) name:NSWindowDidExitFullScreenNotification object:self];
+		[nc addObserver:self selector:@selector(windowWillEnterFullScreen:) name:NSWindowWillEnterFullScreenNotification object:self];
+		[nc addObserver:self selector:@selector(windowWillExitFullScreen:) name:NSWindowWillExitFullScreenNotification object:self];
+	}
+    
+	[self _createTitlebarView];
+	[self _layoutTrafficLightsAndContent];
+	[self _setupTrafficLightsTrackingArea];
+}
 
-    [nc addObserver:self selector:@selector(_updateTitlebarView) name:NSApplicationDidBecomeActiveNotification object:nil];
-    [nc addObserver:self selector:@selector(_updateTitlebarView) name:NSApplicationDidResignActiveNotification object:nil];
-    #if IN_COMPILING_LION
-    if (IN_RUNNING_LION) {
-        [nc addObserver:self selector:@selector(_setupTrafficLightsTrackingArea) name:NSWindowDidExitFullScreenNotification object:nil];
-        [nc addObserver:self selector:@selector(windowWillEnterFullScreen:) name:NSWindowWillEnterFullScreenNotification object:nil];
-        [nc addObserver:self selector:@selector(windowWillExitFullScreen:) name:NSWindowWillExitFullScreenNotification object:nil];
-    }
-    #endif
-    [self _createTitlebarView];
-    [self _layoutTrafficLightsAndContent];
-    [self _setupTrafficLightsTrackingArea];
+- (NSButton *)_windowButtonToLayout:(NSWindowButton)defaultButtonType orUserProvided:(NSButton *)userButton
+{
+	NSButton *defaultButton = [self standardWindowButton:defaultButtonType];
+	if (userButton) {
+		[defaultButton setHidden:YES];
+		defaultButton = userButton;
+	} else if ([defaultButton superview] != [self themeFrameView]) {
+		[defaultButton setHidden:NO];
+	}
+	return defaultButton;
+}
+
+- (NSButton *)_closeButtonToLayout
+{
+	return [self _windowButtonToLayout:NSWindowCloseButton orUserProvided:self.closeButton];
+}
+
+- (NSButton *)_minimizeButtonToLayout
+{
+	return [self _windowButtonToLayout:NSWindowMiniaturizeButton orUserProvided:self.minimizeButton];
+}
+
+- (NSButton *)_zoomButtonToLayout
+{
+	return [self _windowButtonToLayout:NSWindowZoomButton orUserProvided:self.zoomButton];
+}
+
+- (NSButton *)_fullScreenButtonToLayout
+{
+	return [self _windowButtonToLayout:NSWindowFullScreenButton orUserProvided:self.fullScreenButton];
 }
 
 - (void)_layoutTrafficLightsAndContent
 {
-    // Reposition/resize the title bar view as needed
-    [self _recalculateFrameForTitleBarContainer];
+	// Reposition/resize the title bar view as needed
+	[self _recalculateFrameForTitleBarContainer];
+	NSButton *close = [self _closeButtonToLayout];
+	NSButton *minimize = [self _minimizeButtonToLayout];
+	NSButton *zoom = [self _zoomButtonToLayout];
     
-    NSButton *close = [self standardWindowButton:NSWindowCloseButton];
-    NSButton *minimize = [self standardWindowButton:NSWindowMiniaturizeButton];
-    NSButton *zoom = [self standardWindowButton:NSWindowZoomButton];
+	// Set the frame of the window buttons
+	NSRect closeFrame = [close frame];
+	NSRect minimizeFrame = [minimize frame];
+	NSRect zoomFrame = [zoom frame];
+	NSRect titleBarFrame = [_titleBarContainer frame];
+	CGFloat buttonOrigin = 0.0;
+	if (!self.verticalTrafficLightButtons) {
+		if (self.centerTrafficLightButtons) {
+			buttonOrigin = round(NSMidY(titleBarFrame) - INMidHeight(closeFrame));
+		} else {
+			buttonOrigin = NSMaxY(titleBarFrame) - NSHeight(closeFrame) - self.trafficLightButtonsTopMargin;
+		}
+		closeFrame.origin.y = buttonOrigin;
+		minimizeFrame.origin.y = buttonOrigin;
+		zoomFrame.origin.y = buttonOrigin;
+		closeFrame.origin.x = self.trafficLightButtonsLeftMargin;
+		minimizeFrame.origin.x = NSMaxX(closeFrame) + self.trafficLightSeparation;
+		zoomFrame.origin.x = NSMaxX(minimizeFrame) + self.trafficLightSeparation;
+	} else {
+		CGFloat groupHeight = NSHeight(closeFrame) + NSHeight(minimizeFrame) + NSHeight(zoomFrame) + 2.f * (self.trafficLightSeparation - 2.f);
+		if (self.centerTrafficLightButtons) {
+			buttonOrigin = round(NSMidY(titleBarFrame) - groupHeight / 2.f);
+		} else {
+			buttonOrigin = NSMaxY(titleBarFrame) - groupHeight - self.trafficLightButtonsTopMargin;
+		}
+		closeFrame.origin.x = self.trafficLightButtonsLeftMargin;
+		minimizeFrame.origin.x = self.trafficLightButtonsLeftMargin;
+		zoomFrame.origin.x = self.trafficLightButtonsLeftMargin;
+		zoomFrame.origin.y = buttonOrigin;
+		minimizeFrame.origin.y = NSMaxY(zoomFrame) + self.trafficLightSeparation - 2.f;
+		closeFrame.origin.y = NSMaxY(minimizeFrame) + self.trafficLightSeparation - 2.f;
+	}
+	[close setFrame:closeFrame];
+	[minimize setFrame:minimizeFrame];
+	[zoom setFrame:zoomFrame];
     
-    // Set the frame of the window buttons
-    NSRect closeFrame = [close frame];
-    NSRect minimizeFrame = [minimize frame];
-    NSRect zoomFrame = [zoom frame];
-    NSRect titleBarFrame = [_titleBarContainer frame];
-    CGFloat buttonOrigin = 0.0;
-    if ( !self.verticalTrafficLightButtons ) {
-        if ( self.centerTrafficLightButtons ) {
-            buttonOrigin = round(NSMidY(titleBarFrame) - INMidHeight(closeFrame));
-        } else {
-            buttonOrigin = NSMaxY(titleBarFrame) - NSHeight(closeFrame) - INButtonTopOffset;
-        }
-        closeFrame.origin.y = buttonOrigin;
-        minimizeFrame.origin.y = buttonOrigin;
-        zoomFrame.origin.y = buttonOrigin;
-        closeFrame.origin.x = _trafficLightButtonsLeftMargin;
-        minimizeFrame.origin.x = _trafficLightButtonsLeftMargin + [self _trafficLightSeparation];
-        zoomFrame.origin.x = _trafficLightButtonsLeftMargin + [self _trafficLightSeparation] * 2;
-    } else {
-        // in vertical orientation, adjust spacing to match iTunes
-        CGFloat groupHeight = NSHeight(closeFrame) + 2*([self _trafficLightSeparation]-2);
-        if ( self.centerTrafficLightButtons ) {
-            buttonOrigin = round( NSMidY(titleBarFrame) - 0.5*groupHeight );
-        } else {
-            buttonOrigin = NSMaxY(titleBarFrame) - groupHeight - INButtonTopOffset - 2;
-        }
-        closeFrame.origin.x = _trafficLightButtonsLeftMargin;
-        minimizeFrame.origin.x = _trafficLightButtonsLeftMargin;
-        zoomFrame.origin.x = _trafficLightButtonsLeftMargin;
-        closeFrame.origin.y = buttonOrigin + 2*([self _trafficLightSeparation]-2);
-        minimizeFrame.origin.y = buttonOrigin + ([self _trafficLightSeparation]-2);
-        zoomFrame.origin.y = buttonOrigin;
-    }
-    [close setFrame:closeFrame];
-    [minimize setFrame:minimizeFrame];
-    [zoom setFrame:zoomFrame];
+	NSButton *docIconButton = [self standardWindowButton:NSWindowDocumentIconButton];
+	if (docIconButton) {
+		NSRect docButtonIconFrame = [docIconButton frame];
+        
+		if (self.verticallyCenterTitle) {
+			docButtonIconFrame.origin.y = floor(NSMidY(titleBarFrame) - INMidHeight(docButtonIconFrame));
+		} else {
+			docButtonIconFrame.origin.y = NSMaxY(titleBarFrame) - NSHeight(docButtonIconFrame) - INWindowDocumentIconButtonOriginY;
+		}
+        
+		[docIconButton setFrame:docButtonIconFrame];
+	}
     
-    #if IN_COMPILING_LION
-    // Set the frame of the FullScreen button in Lion if available
-    if ( IN_RUNNING_LION ) {
-        NSButton *fullScreen = [self standardWindowButton:NSWindowFullScreenButton];        
-        if( fullScreen ) {
-            NSRect fullScreenFrame = [fullScreen frame];
-            if ( !_setFullScreenButtonRightMargin ) {
-                self.fullScreenButtonRightMargin = NSWidth([_titleBarContainer frame]) - NSMaxX(fullScreen.frame);
-            }
-            fullScreenFrame.origin.x = NSWidth(titleBarFrame) - NSWidth(fullScreenFrame) - _fullScreenButtonRightMargin;
-            if( self.centerFullScreenButton ) {
-                fullScreenFrame.origin.y = round(NSMidY(titleBarFrame) - INMidHeight(fullScreenFrame));
-            } else {
-                fullScreenFrame.origin.y = NSMaxY(titleBarFrame) - NSHeight(fullScreenFrame) - INButtonTopOffset;
-            }
-            [fullScreen setFrame:fullScreenFrame];
-        }
-    }
-    #endif
+	// Set the frame of the FullScreen button in Lion if available
+	if (INRunningLion()) {
+		NSButton *fullScreen = [self _fullScreenButtonToLayout];
+		if (fullScreen) {
+			NSRect fullScreenFrame = [fullScreen frame];
+			if (!_setFullScreenButtonRightMargin) {
+				self.fullScreenButtonRightMargin = NSWidth([_titleBarContainer frame]) - NSMaxX(fullScreen.frame);
+			}
+			fullScreenFrame.origin.x = NSWidth(titleBarFrame) - NSWidth(fullScreenFrame) - _fullScreenButtonRightMargin;
+			if (self.centerFullScreenButton) {
+				fullScreenFrame.origin.y = floor(NSMidY(titleBarFrame) - INMidHeight(fullScreenFrame));
+			} else {
+				fullScreenFrame.origin.y = NSMaxY(titleBarFrame) - NSHeight(fullScreenFrame) - self.fullScreenButtonTopMargin;
+			}
+			[fullScreen setFrame:fullScreenFrame];
+		}
+        
+		NSButton *versionsButton = [self standardWindowButton:NSWindowDocumentVersionsButton];
+		if (versionsButton) {
+			NSRect versionsButtonFrame = [versionsButton frame];
+            
+			if (self.verticallyCenterTitle) {
+				versionsButtonFrame.origin.y = floor(NSMidY(titleBarFrame) - INMidHeight(versionsButtonFrame));
+			} else {
+				versionsButtonFrame.origin.y = NSMaxY(titleBarFrame) - NSHeight(versionsButtonFrame) - INWindowDocumentVersionsButtonOriginY;
+			}
+            
+			[versionsButton setFrame:versionsButtonFrame];
+            
+			// Also ensure that the title font is set
+			if (self.titleFont) {
+				[versionsButton setFont:self.titleFont];
+			}
+		}
+        
+		for (id subview in [[[self contentView] superview] subviews]) {
+			if ([subview isKindOfClass:[NSTextField class]]) {
+				NSTextField *textField = (NSTextField *) subview;
+				NSRect textFieldFrame = [textField frame];
+                
+				if (self.verticallyCenterTitle) {
+					textFieldFrame.origin.y = round(NSMidY(titleBarFrame) - INMidHeight(textFieldFrame));
+				} else {
+					textFieldFrame.origin.y = NSMaxY(titleBarFrame) - NSHeight(textFieldFrame) - INWindowDocumentVersionsDividerOriginY;
+				}
+                
+				[textField setFrame:textFieldFrame];
+                
+				// Also ensure that the font is set
+				if (self.titleFont) {
+					[textField setFont:self.titleFont];
+				}
+			}
+		}
+	}
     
-    [self _repositionContentView];
+	[self _repositionContentView];
 }
 
-- (void)windowWillEnterFullScreen:(NSNotification *)notification 
+- (void)undoManagerDidCloseUndoGroupNotification:(NSNotification *)notification
 {
-    if (_hideTitleBarInFullScreen) {
-        // Recalculate the views when entering from fullscreen
-        _titleBarHeight = 0.0f;
-        [self _layoutTrafficLightsAndContent];
-        [self _displayWindowAndTitlebar];
-        
-        [self _hideTitleBarView:YES];
-    }
+	[self _displayWindowAndTitlebar];
 }
 
-- (void)windowWillExitFullScreen:(NSNotification *)notification 
+- (void)windowWillEnterFullScreen:(NSNotification *)notification
 {
-    if (_hideTitleBarInFullScreen) {
-        _titleBarHeight = _cachedTitleBarHeight;
-        [self _layoutTrafficLightsAndContent];
-        [self _displayWindowAndTitlebar];
+	if (_hideTitleBarInFullScreen) {
+		// Recalculate the views when entering from fullscreen
+		_titleBarHeight = 0.0f;
+		[self _layoutTrafficLightsAndContent];
+		[self _displayWindowAndTitlebar];
         
-        [self _hideTitleBarView:NO];
-    }
+		[self _hideTitleBarView:YES];
+	}
+}
+
+- (void)windowWillExitFullScreen:(NSNotification *)notification
+{
+	if (_hideTitleBarInFullScreen) {
+		_titleBarHeight = _cachedTitleBarHeight;
+		[self _layoutTrafficLightsAndContent];
+		[self _displayWindowAndTitlebar];
+        
+		[self _hideTitleBarView:NO];
+	}
+}
+
+- (void)windowDidExitFullScreen:(NSNotification *)notification
+{
+	[self _layoutTrafficLightsAndContent];
+	[self _setupTrafficLightsTrackingArea];
+}
+
+- (NSView *)themeFrameView
+{
+	return [[self contentView] superview];
 }
 
 - (void)_createTitlebarView
 {
-    // Create the title bar view
-    INTitlebarContainer *container = [[INTitlebarContainer alloc] initWithFrame:NSZeroRect];
-    // Configure the view properties and add it as a subview of the theme frame
-    NSView *themeFrame = [[self contentView] superview];
-    NSView *firstSubview = [[themeFrame subviews] objectAtIndex:0];
-    [self _recalculateFrameForTitleBarContainer];
-    [themeFrame addSubview:container positioned:NSWindowBelow relativeTo:firstSubview];
-    #if __has_feature(objc_arc)
-    _titleBarContainer = container;
-    self.titleBarView = [[INTitlebarView alloc] initWithFrame:NSZeroRect];
-    #else
-    _titleBarContainer = [container autorelease];
-    self.titleBarView = [[[INTitlebarView alloc] initWithFrame:NSZeroRect] autorelease];
-    #endif
+	// Create the title bar view
+	INTitlebarContainer *container = [[INTitlebarContainer alloc] initWithFrame:NSZeroRect];
+	// Configure the view properties and add it as a subview of the theme frame
+	NSView *firstSubview = [[[self themeFrameView] subviews] objectAtIndex:0];
+	[self _recalculateFrameForTitleBarContainer];
+	[[self themeFrameView] addSubview:container positioned:NSWindowBelow relativeTo:firstSubview];
+#if __has_feature(objc_arc)
+	_titleBarContainer = container;
+	self.titleBarView = [[INTitlebarView alloc] initWithFrame:NSZeroRect];
+#else
+	_titleBarContainer = [container autorelease];
+	self.titleBarView = [[[INTitlebarView alloc] initWithFrame:NSZeroRect] autorelease];
+#endif
 }
 
-- (void)_hideTitleBarView:(BOOL)hidden 
+- (void)_hideTitleBarView:(BOOL)hidden
 {
-    [self.titleBarView setHidden:hidden];
+	[self.titleBarView setHidden:hidden];
 }
 
 // Solution for tracking area issue thanks to @Perspx (Alex Rozanski) <https://gist.github.com/972958>
 - (void)_setupTrafficLightsTrackingArea
 {
-    [[[self contentView] superview] viewWillStartLiveResize];
-    [[[self contentView] superview] viewDidEndLiveResize];
+	[[self themeFrameView] viewWillStartLiveResize];
+	[[self themeFrameView] viewDidEndLiveResize];
 }
 
 - (void)_recalculateFrameForTitleBarContainer
 {
-    NSView *themeFrame = [[self contentView] superview];
-    NSRect themeFrameRect = [themeFrame frame];
-    NSRect titleFrame = NSMakeRect(0.0, NSMaxY(themeFrameRect) - _titleBarHeight, NSWidth(themeFrameRect), _titleBarHeight);
-    [_titleBarContainer setFrame:titleFrame];
+	NSRect themeFrameRect = [[self themeFrameView] frame];
+	NSRect titleFrame = NSMakeRect(0.0, NSMaxY(themeFrameRect) - _titleBarHeight, NSWidth(themeFrameRect), _titleBarHeight);
+	[_titleBarContainer setFrame:titleFrame];
+}
+
+- (NSRect)_contentViewFrame
+{
+	NSRect windowFrame = self.frame;
+	NSRect contentRect = [self contentRectForFrameRect:windowFrame];
+    
+	contentRect.size.height = NSHeight(windowFrame) - _titleBarHeight;
+	contentRect.origin = NSZeroPoint;
+    
+	return contentRect;
 }
 
 - (void)_repositionContentView
 {
-    NSView *contentView = [self contentView];
-    NSRect windowFrame = [self frame];
-    NSRect currentContentFrame = [contentView frame];
-    NSRect newFrame = currentContentFrame;
-
-    CGFloat titleHeight = NSHeight(windowFrame) - NSHeight(newFrame);
-    CGFloat extraHeight = _titleBarHeight - titleHeight;
-    newFrame.size.height -= extraHeight;
-
-    if (!NSEqualRects(currentContentFrame, newFrame)) {
-        [contentView setFrame:newFrame];
-        [contentView setNeedsDisplay:YES];
-    }
+	NSView *contentView = [self contentView];
+	NSRect newFrame = [self _contentViewFrame];
+    
+	if (!NSEqualRects([contentView frame], newFrame)) {
+		[contentView setFrame:newFrame];
+		[contentView setNeedsDisplay:YES];
+	}
 }
 
 - (CGFloat)_minimumTitlebarHeight
 {
-    static CGFloat minTitleHeight = 0.0;
-    if ( !minTitleHeight ) {
-        NSRect frameRect = [self frame];
-        NSRect contentRect = [self contentRectForFrameRect:frameRect];
-        minTitleHeight = NSHeight(frameRect) - NSHeight(contentRect);
-    }
-    return minTitleHeight;
+	static CGFloat minTitleHeight = 0.0;
+	if (!minTitleHeight) {
+		NSRect frameRect = [self frame];
+		NSRect contentRect = [self contentRectForFrameRect:frameRect];
+		minTitleHeight = NSHeight(frameRect) - NSHeight(contentRect);
+	}
+	return minTitleHeight;
 }
 
 - (CGFloat)_defaultTrafficLightLeftMargin
 {
-    static CGFloat trafficLightLeftMargin = 0.0;
-    if ( !trafficLightLeftMargin ) {
-        NSButton *close = [self standardWindowButton:NSWindowCloseButton];
-        trafficLightLeftMargin = NSMinX(close.frame);
-    }
-    return trafficLightLeftMargin;
+	static CGFloat trafficLightLeftMargin = 0.0;
+	if (!trafficLightLeftMargin) {
+		NSButton *close = [self _closeButtonToLayout];
+		trafficLightLeftMargin = NSMinX(close.frame);
+	}
+	return trafficLightLeftMargin;
 }
 
-- (CGFloat)_trafficLightSeparation
+- (CGFloat)_defaultTrafficLightSeparation
 {
-    static CGFloat trafficLightSeparation = 0.0;
-    if ( !trafficLightSeparation ) {
-        NSButton *close = [self standardWindowButton:NSWindowCloseButton];
-        NSButton *minimize = [self standardWindowButton:NSWindowMiniaturizeButton];
-        trafficLightSeparation = NSMinX(minimize.frame) - NSMinX(close.frame);
-    }
-    return trafficLightSeparation;    
+	static CGFloat trafficLightSeparation = 0.0;
+	if (!trafficLightSeparation) {
+		NSButton *close = [self _closeButtonToLayout];
+		NSButton *minimize = [self _minimizeButtonToLayout];
+		trafficLightSeparation = NSMinX(minimize.frame) - NSMaxX(close.frame);
+	}
+	return trafficLightSeparation;
 }
 
 - (void)_displayWindowAndTitlebar
 {
-    // Redraw the window and titlebar
-    [_titleBarView setNeedsDisplay:YES];
+	// Redraw the window and titlebar
+	[_titleBarView setNeedsDisplay:YES];
 }
-
 
 - (void)_updateTitlebarView
 {
-    [_titleBarView setNeedsDisplay:YES];
+	[_titleBarView setNeedsDisplay:YES];
+    
+	// "validate" any controls in the titlebar view
+	BOOL isMainWindowAndActive = ([self isMainWindow] && [[NSApplication sharedApplication] isActive]);
+	for (NSView *childView in [_titleBarView subviews]) {
+		if ([childView isKindOfClass:[NSControl class]]) {
+			[(NSControl *) childView setEnabled:isMainWindowAndActive];
+		}
+	}
+}
 
-    // "validate" any controls in the titlebar view
-    BOOL isMainWindowAndActive = ([self isMainWindow] && [[NSApplication sharedApplication] isActive]);
-    for (NSView *childView in [_titleBarView subviews]) {
-        if ([childView isKindOfClass:[NSControl class]]) {
-            [(NSControl *)childView setEnabled:isMainWindowAndActive];
-        }
-    }
++ (NSColor *)defaultTitleBarStartColor:(BOOL)drawsAsMainWindow
+{
+	if (INRunningLion())
+		return drawsAsMainWindow ? [NSColor colorWithDeviceWhite:0.66 alpha:1.0] : [NSColor colorWithDeviceWhite:0.878 alpha:1.0];
+	else
+		return drawsAsMainWindow ? [NSColor colorWithDeviceWhite:0.659 alpha:1.0] : [NSColor colorWithDeviceWhite:0.851 alpha:1.0];
+}
+
++ (NSColor *)defaultTitleBarEndColor:(BOOL)drawsAsMainWindow
+{
+	if (INRunningLion())
+		return drawsAsMainWindow ? [NSColor colorWithDeviceWhite:0.9 alpha:1.0] : [NSColor colorWithDeviceWhite:0.976 alpha:1.0];
+	else
+		return drawsAsMainWindow ? [NSColor colorWithDeviceWhite:0.812 alpha:1.0] : [NSColor colorWithDeviceWhite:0.929 alpha:1.0];
+}
+
++ (NSColor *)defaultBaselineSeparatorColor:(BOOL)drawsAsMainWindow
+{
+	if (INRunningLion())
+		return drawsAsMainWindow ? [NSColor colorWithDeviceWhite:0.408 alpha:1.0] : [NSColor colorWithDeviceWhite:0.655 alpha:1.0];
+	else
+		return drawsAsMainWindow ? [NSColor colorWithDeviceWhite:0.318 alpha:1.0] : [NSColor colorWithDeviceWhite:0.600 alpha:1.0];
+}
+
++ (NSColor *)defaultTitleTextColor:(BOOL)drawsAsMainWindow
+{
+	return drawsAsMainWindow ? [NSColor colorWithDeviceWhite:56.0/255.0 alpha:1.0] : [NSColor colorWithDeviceWhite:56.0/255.0 alpha:0.5];
 }
 
 @end

--- a/OpenEmu/INWindowButton.h
+++ b/OpenEmu/INWindowButton.h
@@ -1,0 +1,77 @@
+//
+//  INWindowButton.h
+//
+//  Copyright 2013-2014 Vladislav Alexeev. All rights reserved.
+//
+//  Licensed under the BSD 2-clause License. See LICENSE file distributed in the source
+//  code of this project.
+//
+
+#import <Cocoa/Cocoa.h>
+
+#if __has_feature(objc_arc)
+#define INAppStoreWindowStrong strong
+#define INAppStoreWindowBridge __bridge
+#else
+#define INAppStoreWindowStrong retain
+#define INAppStoreWindowBridge
+#endif
+
+/**
+ A concrete NSButton subclass that allows to mimic standard window title bar "traffic light" buttons
+ and replace their graphics with custom ones.
+ */
+@interface INWindowButton : NSButton
+
+/**
+ The group identifier the receiver was initialized with.
+ */
+@property (nonatomic, copy, readonly) NSString *groupIdentifier;
+
+/**
+ An image for the normal state.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSImage *activeImage;
+
+/**
+ An image for the normal state, but displayed when receiver's window in not a key.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSImage *activeNotKeyWindowImage;
+
+/**
+ An image used in disabled state.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSImage *inactiveImage;
+
+/**
+ An image used when user hovers receiver with mouse pointer.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSImage *rolloverImage;
+
+/**
+ An image for the pressed state.
+ */
+@property (nonatomic, INAppStoreWindowStrong) NSImage *pressedImage;
+
+/**
+ @param size Designated size of the button. System size is 14x16 and you are considered to use it.
+ @param groupIdentifier ID of the group which will apply rollover effect to its members.
+ You may pass \c nil.
+ @see initWithSize:groupIdentifier:
+ */
++ (instancetype)windowButtonWithSize:(NSSize)size groupIdentifier:(NSString *)groupIdentifier;
+
+/**
+ @abstract Designated initializer.
+ @discussion Initializes the receiver with the given size and includes it in the group with the
+ given identifier.
+ Groups are used to apply rollover effect to all buttons that are inside the same group.
+ For example, close, minimize and zoom buttons should be inside the same group since they all get a
+ rollover effect when the mouse pointer hovers over one of these buttons.
+ @param size Designated size of the button. System size is 14x16 and you are considered to use it.
+ @param groupIdentifier ID of the group which will apply rollover effect to its members.
+ You may pass \c nil.
+ */
+- (instancetype)initWithSize:(NSSize)size groupIdentifier:(NSString *)groupIdentifier;
+
+@end

--- a/OpenEmu/INWindowButton.m
+++ b/OpenEmu/INWindowButton.m
@@ -1,0 +1,312 @@
+//
+//  INWindowButton.m
+//
+//  Copyright 2013-2014 Vladislav Alexeev. All rights reserved.
+//
+//  Licensed under the BSD 2-clause License. See LICENSE file distributed in the source
+//  code of this project.
+//
+
+#import "INWindowButton.h"
+
+#pragma mark - Window Button Group
+
+NSString *const INWindowButtonGroupDidUpdateRolloverStateNotification = @"INWindowButtonGroupDidUpdateRolloverStateNotification";
+NSString *const kINWindowButtonGroupDefault = @"com.indragie.inappstorewindow.defaultWindowButtonGroup";
+
+@interface INWindowButtonGroup : NSObject
+
++ (instancetype)groupWithIdentifier:(NSString *)identifier;
+@property (nonatomic, copy, readonly) NSString *identifier;
+
+- (void)didCaptureMousePointer;
+- (void)didReleaseMousePointer;
+- (BOOL)shouldDisplayRollOver;
+
+- (void)resetMouseCaptures;
+
+@end
+
+@interface INWindowButtonGroup ()
+@property (nonatomic, assign) NSInteger numberOfCaptures;
+@end
+
+@implementation INWindowButtonGroup
+
++ (instancetype)groupWithIdentifier:(NSString *)identifier
+{
+	static NSMutableDictionary *groups = nil;
+	if (groups == nil) {
+		groups = [[NSMutableDictionary alloc] init];
+	}
+
+	if (identifier == nil) {
+		identifier = kINWindowButtonGroupDefault;
+	}
+
+	INWindowButtonGroup *group = [groups objectForKey:identifier];
+	if (group == nil) {
+		group = [[[self class] alloc] initWithIdentifier:identifier];
+		[groups setObject:group forKey:identifier];
+#if !__has_feature(objc_arc)
+        [group release];
+#endif
+	}
+	return group;
+}
+
+- (instancetype)initWithIdentifier:(NSString *)identifier
+{
+	self = [super init];
+	if (self) {
+		_identifier = [identifier copy];
+	}
+	return self;
+}
+
+#if !__has_feature(objc_arc)
+- (void)dealloc
+{
+	[_identifier release];
+	[super dealloc];
+}
+#endif
+
+- (void)setNumberOfCaptures:(NSInteger)numberOfCaptures
+{
+	if (_numberOfCaptures != numberOfCaptures && numberOfCaptures >= 0) {
+		_numberOfCaptures = numberOfCaptures;
+		[[NSNotificationCenter defaultCenter] postNotificationName:INWindowButtonGroupDidUpdateRolloverStateNotification
+															object:self];
+	}
+}
+
+- (void)didCaptureMousePointer
+{
+	self.numberOfCaptures++;
+}
+
+- (void)didReleaseMousePointer
+{
+	self.numberOfCaptures--;
+}
+
+- (BOOL)shouldDisplayRollOver
+{
+	return (self.numberOfCaptures > 0);
+}
+
+- (void)resetMouseCaptures
+{
+	self.numberOfCaptures = 0;
+}
+
+@end
+
+#pragma mark - Window Button
+
+@interface INWindowButton ()
+@property (nonatomic, copy) NSString *groupIdentifier;
+@property (nonatomic, INAppStoreWindowStrong, readonly) INWindowButtonGroup *group;
+@property (nonatomic, INAppStoreWindowStrong) NSTrackingArea *mouseTrackingArea;
+
+@end
+
+@implementation INWindowButton
+
++ (instancetype)windowButtonWithSize:(NSSize)size groupIdentifier:(NSString *)groupIdentifier
+{
+	INWindowButton *button = [[self alloc] initWithSize:size groupIdentifier:groupIdentifier];
+	return button;
+}
+
+#pragma mark - Init and Dealloc
+
+- (instancetype)initWithSize:(NSSize)size groupIdentifier:(NSString *)groupIdentifier
+{
+	self = [super initWithFrame:NSMakeRect(0, 0, size.width, size.height)];
+	if (self) {
+		_groupIdentifier = [groupIdentifier copy];
+		[self setButtonType:NSMomentaryChangeButton];
+		[self setBordered:NO];
+		[self setTitle:@""];
+		[self.cell setHighlightsBy:NSContentsCellMask];
+		[self.cell setImageDimsWhenDisabled:NO];
+
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowButtonGroupDidUpdateRolloverStateNotification:) name:INWindowButtonGroupDidUpdateRolloverStateNotification object:self.group];
+	}
+	return self;
+}
+
+- (void)dealloc
+{
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+#if !__has_feature(objc_arc)
+	[_activeImage release];
+	[_inactiveImage release];
+	[_activeNotKeyWindowImage release];
+	[_rolloverImage release];
+	[_groupIdentifier release];
+	[super dealloc];
+#endif
+}
+
+#pragma mark - Group
+
+- (INWindowButtonGroup *)group
+{
+	return [INWindowButtonGroup groupWithIdentifier:self.groupIdentifier];
+}
+
+- (void)windowButtonGroupDidUpdateRolloverStateNotification:(NSNotification *)n
+{
+	[self updateRollOverImage];
+}
+
+#pragma mark - Tracking Area
+
+- (void)updateTrackingAreas
+{
+	[super updateTrackingAreas];
+
+	if (self.mouseTrackingArea) {
+		[self removeTrackingArea:self.mouseTrackingArea];
+	}
+
+	NSTrackingArea *mouseTrackingArea = [[NSTrackingArea alloc] initWithRect:NSInsetRect(self.bounds, -4, -4)
+																	 options:NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways
+																	   owner:self
+																	userInfo:nil];
+
+	[self addTrackingArea:self.mouseTrackingArea = mouseTrackingArea];
+#if !__has_feature(objc_arc)
+    [mouseTrackingArea release];
+#endif
+}
+
+#pragma mark - Window State Handling
+
+- (void)viewDidMoveToWindow
+{
+	if (self.window) {
+		[self updateImage];
+	}
+}
+
+- (void)viewWillMoveToWindow:(NSWindow *)newWindow
+{
+	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+	if (self.window) {
+		[nc removeObserver:self name:NSWindowDidBecomeKeyNotification object:self.window];
+		[nc removeObserver:self name:NSWindowDidResignKeyNotification object:self.window];
+		[nc removeObserver:self name:NSWindowDidMiniaturizeNotification object:self.window];
+		if ([NSWindow instancesRespondToSelector:@selector(toggleFullScreen:)]) {
+			[nc removeObserver:self name:NSWindowWillEnterFullScreenNotification object:self.window];
+			[nc removeObserver:self name:NSWindowWillExitFullScreenNotification object:self.window];
+		}
+	}
+	if (newWindow != nil) {
+		[nc addObserver:self selector:@selector(windowDidChangeFocus:) name:NSWindowDidBecomeKeyNotification object:newWindow];
+		[nc addObserver:self selector:@selector(windowDidChangeFocus:) name:NSWindowDidResignKeyNotification object:newWindow];
+		[nc addObserver:self selector:@selector(windowDidMiniaturize:) name:NSWindowDidMiniaturizeNotification object:newWindow];
+		if ([NSWindow instancesRespondToSelector:@selector(toggleFullScreen:)]) {
+			[nc addObserver:self selector:@selector(windowWillEnterFullScreen:) name:NSWindowWillEnterFullScreenNotification object:newWindow];
+			[nc addObserver:self selector:@selector(windowWillExitFullScreen:) name:NSWindowWillExitFullScreenNotification object:newWindow];
+		}
+	}
+}
+
+- (void)windowDidChangeFocus:(NSNotification *)n
+{
+	[self updateImage];
+}
+
+- (void)windowWillEnterFullScreen:(NSNotification *)n
+{
+	[self.group resetMouseCaptures];
+	[self setHidden:YES];
+}
+
+- (void)windowWillExitFullScreen:(NSNotification *)n
+{
+	[self.group resetMouseCaptures];
+	[self setHidden:NO];
+}
+
+- (void)windowDidMiniaturize:(NSNotification *)notification
+{
+	[self.group resetMouseCaptures];
+}
+
+#pragma mark - Event Handling
+
+- (void)viewDidEndLiveResize
+{
+	[super viewDidEndLiveResize];
+	[self.group resetMouseCaptures];
+}
+
+- (void)mouseEntered:(NSEvent *)theEvent
+{
+	[super mouseEntered:theEvent];
+	[self.group didCaptureMousePointer];
+	[self updateRollOverImage];
+}
+
+- (void)mouseExited:(NSEvent *)theEvent
+{
+	[super mouseExited:theEvent];
+	[self.group didReleaseMousePointer];
+	[self updateRollOverImage];
+}
+
+#pragma mark - Button Appearance
+
+- (void)setPressedImage:(NSImage *)pressedImage
+{
+	self.alternateImage = pressedImage;
+}
+
+- (NSImage *)pressedImage
+{
+	return self.alternateImage;
+}
+
+- (void)setEnabled:(BOOL)enabled
+{
+	[super setEnabled:enabled];
+	if (enabled) {
+		self.image = self.activeImage;
+	} else {
+		self.image = self.inactiveImage;
+	}
+}
+
+- (void)updateRollOverImage
+{
+	if ([self.group shouldDisplayRollOver] && [self isEnabled]) {
+		self.image = self.rolloverImage;
+	} else {
+		[self updateImage];
+	}
+}
+
+- (void)updateImage
+{
+	if ([self.window isKeyWindow]) {
+		[self updateActiveImage];
+	} else {
+		self.image = self.activeNotKeyWindowImage;
+	}
+}
+
+- (void)updateActiveImage
+{
+	if ([self isEnabled]) {
+		self.image = self.activeImage;
+	} else {
+		self.image = self.inactiveImage;
+	}
+}
+
+@end

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -826,6 +826,7 @@
 		94FEFA5418A80EF30033A762 /* _ntsc-pass1-vertex.inc in Copy Filters Folder To App Resources */ = {isa = PBXBuildFile; fileRef = 94FEFA4D18A80ECC0033A762 /* _ntsc-pass1-vertex.inc */; };
 		94FEFA5518A80EF30033A762 /* _ntsc-pass2-decode.inc in Copy Filters Folder To App Resources */ = {isa = PBXBuildFile; fileRef = 94FEFA4E18A80ECD0033A762 /* _ntsc-pass2-decode.inc */; };
 		94FEFA5618A80EF30033A762 /* _ntsc-pass2-vertex.inc in Copy Filters Folder To App Resources */ = {isa = PBXBuildFile; fileRef = 94FEFA4F18A80ECD0033A762 /* _ntsc-pass2-vertex.inc */; };
+		A6F3061218AF3BB7007CF986 /* INWindowButton.m in Sources */ = {isa = PBXBuildFile; fileRef = A6F3061118AF3BB7007CF986 /* INWindowButton.m */; };
 		C60238E61794FB1B00F4AF6C /* OpenEmuXPCCommunicator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C60238E41794FB1B00F4AF6C /* OpenEmuXPCCommunicator.framework */; };
 		C6096192179B461C00239067 /* OEXPCGameCoreManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C6096191179B461C00239067 /* OEXPCGameCoreManager.m */; };
 		C609619A179B6E3F00239067 /* OpenEmuXPCHelperApp.m in Sources */ = {isa = PBXBuildFile; fileRef = C6096199179B6E3F00239067 /* OpenEmuXPCHelperApp.m */; };
@@ -2504,6 +2505,8 @@
 		94FEFA4D18A80ECC0033A762 /* _ntsc-pass1-vertex.inc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.pascal; path = "_ntsc-pass1-vertex.inc"; sourceTree = "<group>"; };
 		94FEFA4E18A80ECD0033A762 /* _ntsc-pass2-decode.inc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.pascal; path = "_ntsc-pass2-decode.inc"; sourceTree = "<group>"; };
 		94FEFA4F18A80ECD0033A762 /* _ntsc-pass2-vertex.inc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.pascal; path = "_ntsc-pass2-vertex.inc"; sourceTree = "<group>"; };
+		A6F3061018AF3BB7007CF986 /* INWindowButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INWindowButton.h; sourceTree = "<group>"; };
+		A6F3061118AF3BB7007CF986 /* INWindowButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = INWindowButton.m; sourceTree = "<group>"; };
 		C60238E41794FB1B00F4AF6C /* OpenEmuXPCCommunicator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuXPCCommunicator.framework; sourceTree = "<group>"; };
 		C60238E8179510C600F4AF6C /* OEGameCoreHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OEGameCoreHelper.h; sourceTree = "<group>"; };
 		C609618F179B278C00239067 /* OEXPCGameCoreHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OEXPCGameCoreHelper.h; sourceTree = "<group>"; };
@@ -3866,6 +3869,8 @@
 				53439B5913B93255005C0CC8 /* OEAttributedTextFieldCell.m */,
 				53439B5B13B9326D005C0CC8 /* INAppStoreWindow.h */,
 				53439B5C13B9326D005C0CC8 /* INAppStoreWindow.m */,
+				A6F3061018AF3BB7007CF986 /* INWindowButton.h */,
+				A6F3061118AF3BB7007CF986 /* INWindowButton.m */,
 				83B72F4F15024B1E0052BCA0 /* OEAppStoreWindow.h */,
 				83B72F5015024B1E0052BCA0 /* OEAppStoreWindow.m */,
 				53439B5E13B93276005C0CC8 /* Toolbar */,
@@ -7636,6 +7641,7 @@
 				832D29401451A68700BDF950 /* OEMainWindowController.m in Sources */,
 				832FA8801455526E00BBBD94 /* NSControl+OEAdditions.m in Sources */,
 				8301557B1456BF7A0093D681 /* OEGameViewController.m in Sources */,
+				A6F3061218AF3BB7007CF986 /* INWindowButton.m in Sources */,
 				83AAC32914581699005ADD16 /* OESetupAssistantBackgroundView.m in Sources */,
 				83BABBEE1458978B0097F6B2 /* OESetupAssistantTableView.m in Sources */,
 				83025E60146BDD5E00A06EF9 /* OECoreTableButtonCell.m in Sources */,


### PR DESCRIPTION
...n createGradientWithColors".

Replace calls to IN_CGColorCreate with calls to -[NSColor CGColor]. Delete the category that defines IN_CGColorCreate. As suggested by Clobber in #1128.

Tested on 13B42 and saw no visual differences and no more leaks.
