### PR TITLE
Attempt to improve scrolling speed

### DIFF
--- a/OpenEmu/OECoverGridDataSourceItem.h
+++ b/OpenEmu/OECoverGridDataSourceItem.h
@@ -40,6 +40,7 @@
 
 - (NSImage *)gridImage;
 - (NSImage *)gridImageWithSize:(NSSize)size;
+- (NSURL *)gridImageURLWithSize:(NSSize)aSize;
 - (BOOL)hasImage;
 - (NSSize)actualGridImageSizeforSize:(NSSize)aSize;
 - (void)setGridImage:(NSImage *)gridImage;

--- a/OpenEmu/OECoverGridViewCell.m
+++ b/OpenEmu/OECoverGridViewCell.m
@@ -446,6 +446,7 @@ __strong static OEThemeImage *selectorRingImage = nil;
     [self setTitle:@""];
     [self setRating:0];
     [self setImage:nil];
+    [self setIndicationType: OECoverGridViewCellIndicationTypeNone];
 
     // Prepare the _imageLayer
     [_imageLayer setHidden:NO];

--- a/OpenEmu/OEDBDataSourceAdditions.m
+++ b/OpenEmu/OEDBDataSourceAdditions.m
@@ -75,6 +75,11 @@ static NSString * OE_stringFromElapsedTime(NSTimeInterval);
     return [[self boxImage] imageForSize:aSize];
 }
 
+- (NSURL *)gridImageURLWithSize:(NSSize)aSize
+{
+    return [[self boxImage] urlForSize:aSize];
+}
+
 - (BOOL)hasImage
 {
     return [self boxImage] != nil;

--- a/OpenEmu/OEDBImage.h
+++ b/OpenEmu/OEDBImage.h
@@ -38,6 +38,7 @@
 // returns image with highest resolution
 - (NSImage *)originalImage;
 - (NSImage *)imageForSize:(NSSize)size;
+- (NSURL *)urlForSize:(NSSize)size;
 - (NSSize)sizeOfThumbnailForSize:(NSSize)size;
 
 @property (nonatomic, retain) NSString * sourceURL;

--- a/OpenEmu/OEDBImage.m
+++ b/OpenEmu/OEDBImage.m
@@ -27,7 +27,9 @@
 #import "OEDBImage.h"
 #import "OEDBImageThumbnail.h"
 #import "OELibraryDatabase.h"
+
 @interface OEDBImage ()
+
 @end
 #pragma mark -
 @implementation OEDBImage
@@ -69,7 +71,13 @@
 }
 
 - (NSImage *)imageForSize:(NSSize)size
-{    
+{
+    NSImage *image = [[NSImage alloc] initWithContentsOfURL:[self urlForSize:size]];
+    return image;
+}
+
+- (NSURL *)urlForSize:(NSSize)size
+{
     NSSet *thumbnailsSet = [self valueForKey:@"versions"];
     
     NSSortDescriptor *sortDescr = [NSSortDescriptor sortDescriptorWithKey:@"width" ascending:YES];
@@ -92,9 +100,10 @@
     if(!usableThumbnail) return nil;
     
     NSURL *url = [[[self libraryDatabase] coverFolderURL] URLByAppendingPathComponent:[usableThumbnail relativePath]];
-    NSImage *image = [[NSImage alloc] initWithContentsOfURL:url];
-    return image;
+    return url;
 }
+
+
 
 
 - (NSSize)sizeOfThumbnailForSize:(NSSize)size

--- a/OpenEmu/OEGridView.h
+++ b/OpenEmu/OEGridView.h
@@ -39,6 +39,7 @@
 - (NSDragOperation)gridView:(OEGridView *)gridView validateDrop:(id<NSDraggingInfo>)sender;
 - (NSDragOperation)gridView:(OEGridView *)gridView draggingUpdated:(id<NSDraggingInfo>)sender;
 - (BOOL)gridView:(OEGridView *)gridView acceptDrop:(id<NSDraggingInfo>)sender;
+- (void)viewDidStopScrolling:(OEGridView*)gridView;
 
 - (BOOL)gridView:(OEGridView *)gridView shouldTypeSelectForEvent:(NSEvent *)event withCurrentSearchString:(NSString *)searchString;
 - (NSString*)gridView:(OEGridView *)gridView typeSelectStringForItemAtIndex:(NSUInteger)idx;


### PR DESCRIPTION
Scrolling was incredibly laggy on my Macbook, so I cached the images by URL in
an NSCache - which will automatically get flushed when there’s low
memory.

The cache is populated on a background thread while the user scrolls,
and the grid view waits until scrolling has slowed or completely
stopped to update the images.

Note that it might need a bit of cleaning up. I’m a complete beginner
at Objective-C. Seems to work okay, though.
