### PR TITLE
Fix controller naming inconsistency

### DIFF
--- a/OpenEmu/Controller-Database.plist
+++ b/OpenEmu/Controller-Database.plist
@@ -2212,14 +2212,14 @@
 						<key>Direction</key>
 						<integer>1</integer>
 						<key>Name</key>
-						<string>Right Analog Up</string>
+						<string>Classic Right Analog Up</string>
 					</dict>
 					<key>OEControllerWiimoteClassicRightAnalogDown</key>
 					<dict>
 						<key>Direction</key>
 						<integer>-1</integer>
 						<key>Name</key>
-						<string>Right Analog Down</string>
+						<string>Classic Right Analog Down</string>
 					</dict>
 				</dict>
 			</dict>


### PR DESCRIPTION
Classic controller's RIght analog Up and Down labels on the mapping screen did not begin with "Classic" like all the rest of the buttons on the controller.
