### PR TITLE
Show HUD when launching games in fullscreen (to hide cursor)

### DIFF
--- a/OpenEmu/OEGameControlsBar.m
+++ b/OpenEmu/OEGameControlsBar.m
@@ -577,6 +577,7 @@ NSString *const OEGameControlsBarShowsAudioOutput       = @"HUDBarShowAudioOutpu
 {
     OEHUDControlsBarView *view = [[[self contentView] subviews] lastObject];
     [[view fullScreenButton] setState:NSOnState];
+    [self mouseMoved:NULL];  // Show HUD because fullscreen animation makes the cursor appear
 }
 
 - (void)parentWindowWillExitFullScreen:(NSNotification *)notification;


### PR DESCRIPTION
This fixes a problem when launching games in fullscreen,
where the cursor would appear on the screen and not hide,
requiring further user interaction to make it disappear.

This happened because the full screen animation seems to
make the cursor appear on the screen, for reasons unknow to myself.

Simply hiding the cursor on NSWindowDidEnterFullScreenNotification,
instead of showing HUD controll bar, was also possibility,
but sometimes it wouldn't work, presumably because the event would
be triggered slightly before the fullscreen animation finished,
so the cursor would get displayed again.
