### PR TITLE
Use TEXCOORD semantic for all texture coordinates.

### DIFF
--- a/OpenEmu/Shaders/HQx/_pass1.cg
+++ b/OpenEmu/Shaders/HQx/_pass1.cg
@@ -46,9 +46,9 @@ struct out_vertex {
 	float4 position : POSITION;
 	float4 color    : COLOR;
 	float2 texCoord : TEXCOORD0;
-	float4 t1;
-	float4 t2;
-	float4 t3;
+	float4 t1       : TEXCOORD1;
+	float4 t2       : TEXCOORD2;
+	float4 t3       : TEXCOORD3;
 };
 
 /*    VERTEX_SHADER    */
@@ -99,7 +99,7 @@ float4 main_fragment(in out_vertex VAR, uniform sampler2D decal : TEXUNIT0, unif
 	float3 w3  = mul(yuv, tex2D(decal, VAR.t1.zw).rgb);
 
 	float3 w4  = mul(yuv, tex2D(decal, VAR.t2.xw).rgb);
-	float3 w5  = mul(yuv, tex2D(decal, VAR.texCoord).rgb);
+	float3 w5  = mul(yuv, tex2D(decal, VAR.t2.yw).rgb);
 	float3 w6  = mul(yuv, tex2D(decal, VAR.t2.zw).rgb);
 
 	float3 w7  = mul(yuv, tex2D(decal, VAR.t3.xw).rgb);

--- a/OpenEmu/Shaders/SABR.cg
+++ b/OpenEmu/Shaders/SABR.cg
@@ -78,13 +78,13 @@ struct out_vertex {
 	half4 pos : POSITION;
 	half4 color : COLOR;
 	float2 tc : TEXCOORD0;
-	float4 xyp_1_2_3;
-	float4 xyp_5_10_15;
-	float4 xyp_6_7_8;
-	float4 xyp_9_14_9;
-	float4 xyp_11_12_13;
-	float4 xyp_16_17_18;
-	float4 xyp_21_22_23;
+	float4 xyp_1_2_3 : TEXCOORD1;
+	float4 xyp_5_10_15 : TEXCOORD2;
+	float4 xyp_6_7_8 : TEXCOORD3;
+	float4 xyp_9_14_9 : TEXCOORD4;
+	float4 xyp_11_12_13 : TEXCOORD5;
+	float4 xyp_16_17_18 : TEXCOORD6;
+	float4 xyp_21_22_23 : TEXCOORD7;
 };
 
 /* VERTEX SHADER */


### PR DESCRIPTION
This fixes a problem with the HQx shader I had to work around previously. I also applied the same fix to SABR, hopefully that will solve issue #1749.