### PR TITLE
Calculate bounding box around control key name. Fixes #1869

### DIFF
--- a/OpenEmu/OEControlsButtonSetupView.m
+++ b/OpenEmu/OEControlsButtonSetupView.m
@@ -286,7 +286,7 @@ NSComparisonResult headerSortingFunction(id obj1, id obj2, void *context)
                 NSTextField *label = animated([group objectAtIndex:j + 1]);
                 NSRect labelRect = NSIntegralRect(NSMakeRect(leftGap, buttonRect.origin.y - 4, width - leftGap - labelButtonSpacing - buttonWidth, itemHeight));
                 
-                BOOL multiline = [label attributedStringValue].size.width + 5 >= labelRect.size.width;
+                BOOL multiline = [label.stringValue sizeWithAttributes:@{NSFontAttributeName: label.font}].width + 5 >= labelRect.size.width;
                 if(multiline)
                 {
                     labelRect.size.height += 10;


### PR DESCRIPTION
Calculates the bounding box around the text using the font specified in the label. Otherwise it provides a width that is different from what is actually rendered.

Before:
![58b8735c-cf55-11e4-8ccd-ab7bec5cd61d](https://cloud.githubusercontent.com/assets/892593/6928526/9aea54aa-d7c2-11e4-8318-68eee6130aca.png)

After:
![screen shot 2015-03-31 at 4 24 44 pm](https://cloud.githubusercontent.com/assets/892593/6928532/a4a419b8-d7c2-11e4-8c4e-651ed7502a2c.png)
