### PR TITLE
Update Playstation plist button symbols to match PSP's.

### DIFF
--- a/OpenEmu/PlayStation/PlayStation-Info.plist
+++ b/OpenEmu/PlayStation/PlayStation-Info.plist
@@ -120,35 +120,27 @@
 		<array>
 			<dict>
 				<key>OEControlListKeyLabelKey</key>
-				<string>△ </string>
+				<string>△</string>
 				<key>OEControlListKeyNameKey</key>
 				<string>OEPSXButtonTriangle</string>
-				<key>OEControlListKeyFontFamilyKey</key>
-				<string>Apple LiGothic</string>
 			</dict>
 			<dict>
 				<key>OEControlListKeyLabelKey</key>
-				<string>○ </string>
+				<string>◯</string>
 				<key>OEControlListKeyNameKey</key>
 				<string>OEPSXButtonCircle</string>
-				<key>OEControlListKeyFontFamilyKey</key>
-				<string>Apple LiGothic</string>
 			</dict>
 			<dict>
 				<key>OEControlListKeyLabelKey</key>
-				<string>✕ </string>
+				<string>✕</string>
 				<key>OEControlListKeyNameKey</key>
 				<string>OEPSXButtonCross</string>
-				<key>OEControlListKeyFontFamilyKey</key>
-				<string>Apple LiGothic</string>
 			</dict>
 			<dict>
 				<key>OEControlListKeyLabelKey</key>
-				<string>□ </string>
+				<string>▢</string>
 				<key>OEControlListKeyNameKey</key>
 				<string>OEPSXButtonSquare</string>
-				<key>OEControlListKeyFontFamilyKey</key>
-				<string>Apple LiGothic</string>
 			</dict>
 		</array>
 		<array>


### PR DESCRIPTION
For consistency's sake. Gets rid of the custom font stuff too, which can cause problems.