### PR TITLE
Use El Capitan system typeface in UI

### DIFF
--- a/Interface Graphics/Theme.plist
+++ b/Interface Graphics/Theme.plist
@@ -24,7 +24,7 @@
 		<key>about_github_link</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -58,7 +58,7 @@
 		<key>about_website_link</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -94,7 +94,7 @@
 		<key>dark_button</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -125,7 +125,7 @@
 		<key>dark_button_small</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -156,7 +156,7 @@
 		<key>dark_checkbox</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -191,7 +191,7 @@
 			<key>Color</key>
 			<string>white</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>States</key>
@@ -227,11 +227,11 @@
 			<key>Color</key>
 			<string>rgb(227,227,227)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
-				<real>1</real>
+				<integer>1</integer>
 				<key>Color</key>
 				<string>rgba(0,0,0,0.4)</string>
 				<key>Offset</key>
@@ -245,7 +245,7 @@
 		<key>game_scanner_fix_issues</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>States</key>
@@ -290,7 +290,7 @@
 			<key>Color</key>
 			<string>rgba(174,173,173,1.0)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -312,7 +312,7 @@
 			<key>Color</key>
 			<string>white</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -334,7 +334,7 @@
 			<key>Color</key>
 			<string>rgb(184, 184, 184)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -358,7 +358,7 @@
 			<key>Color</key>
 			<string>rgba(174,173,173,1.0)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -380,7 +380,7 @@
 			<key>Color</key>
 			<string>rgba(156,156,156,1.0)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -398,7 +398,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -455,7 +455,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -512,7 +512,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -557,11 +557,11 @@
 			<key>Color</key>
 			<string>rgb(227,227,227)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
-				<real>1</real>
+				<integer>1</integer>
 				<key>Color</key>
 				<string>rgba(0,0,0,0.4)</string>
 				<key>Offset</key>
@@ -577,7 +577,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -618,7 +618,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -659,7 +659,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -698,7 +698,7 @@
 		<key>hud_checkbox</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -733,7 +733,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -778,7 +778,7 @@
 			<key>Color</key>
 			<string>#dbdbdb</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>Traits</key>
@@ -793,7 +793,7 @@
 			<key>Color</key>
 			<string>#f2f2f2</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>Traits</key>
@@ -808,7 +808,7 @@
 			<key>Color</key>
 			<string>black</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>Traits</key>
@@ -821,7 +821,7 @@
 			<key>Color</key>
 			<string>black</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>States</key>
@@ -855,7 +855,7 @@
 		<key>open_weblink</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>States</key>
@@ -909,7 +909,7 @@
 			<key>Color</key>
 			<string>rgb(245,245,245)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -931,7 +931,7 @@
 			<key>Color</key>
 			<string>rgb(245,245,245)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -953,7 +953,7 @@
 			<key>Color</key>
 			<string>rgb(245,245,245)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -975,7 +975,7 @@
 			<key>Color</key>
 			<string>#526ba0</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -997,7 +997,7 @@
 			<key>Color</key>
 			<string>rgb(215,215,215)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1019,7 +1019,7 @@
 			<key>Color</key>
 			<string>#d9d9d9</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1041,7 +1041,7 @@
 			<key>Color</key>
 			<string>rgb(227,227,227)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1063,7 +1063,7 @@
 			<key>Color</key>
 			<string>black</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1083,7 +1083,7 @@
 		<key>search_field</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1128,7 +1128,7 @@
 			<key>Background Color</key>
 			<string>#808080</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1178,11 +1178,11 @@
 			<key>Color</key>
 			<string>black</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
-				<real>1</real>
+				<integer>1</integer>
 				<key>Color</key>
 				<string>rgba(255,255,255,0.25)</string>
 				<key>Offset</key>
@@ -1200,7 +1200,7 @@
 			<key>Color</key>
 			<string>#eff3fd</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1222,7 +1222,7 @@
 			<key>Color</key>
 			<string>#eff3fd</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1244,7 +1244,7 @@
 			<key>Color</key>
 			<string>#eff3fd</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1266,7 +1266,7 @@
 			<key>Color</key>
 			<string>#929DA5</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1284,7 +1284,7 @@
 			<key>Color</key>
 			<string>rgba(127,127,127,1.0)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1302,7 +1302,7 @@
 		<key>homebrew_developer</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Size</key>
 			<integer>14</integer>
 			<key>Shadow</key>
@@ -1338,7 +1338,7 @@
 			<key>Color</key>
 			<string>rgba(127,127,127,1.0)</string>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1354,7 +1354,7 @@
 		<key>sidebar_group</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1376,7 +1376,7 @@
 		<key>sidebar_item</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>States</key>
@@ -1434,7 +1434,7 @@
 		<key>sidebar_item_badge</key>
 		<dict>
 			<key>Family</key>
-			<string>Lucida Grande</string>
+			<string>San Francisco</string>
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Shadow</key>

--- a/OpenEmu/OEBlankSlateView.m
+++ b/OpenEmu/OEBlankSlateView.m
@@ -220,7 +220,7 @@ NSString * const OECDBasedGamesUserGuideURLString = @"https://github.com/OpenEmu
     [textView setEditable:NO];
     [textView setSelectionGranularity:NSSelectByCharacter];
     [textView setDelegate:self];
-    [textView setFont:[[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:0 size:11.0]];
+    [textView setFont:[NSFont systemFontOfSize:11]];
     [textView setTextColor:[NSColor colorWithDeviceWhite:0.86 alpha:1.0]];
     [textView setTextContainerInset:NSMakeSize(0, 0)];
 
@@ -268,7 +268,7 @@ NSString * const OECDBasedGamesUserGuideURLString = @"https://github.com/OpenEmu
     [shadow setShadowBlurRadius:0];
     
     NSDictionary *dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:15 size:11.0], NSFontAttributeName,
+                                [NSFont systemFontOfSize:11], NSFontAttributeName,
                                 shadow, NSShadowAttributeName,
                                 [NSColor colorWithDeviceWhite:1.0 alpha:1.0], NSForegroundColorAttributeName,
                                 nil];
@@ -322,7 +322,7 @@ NSString * const OECDBasedGamesUserGuideURLString = @"https://github.com/OpenEmu
     [shadow setShadowBlurRadius:0];
     
     NSDictionary *dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:15 size:11.0], NSFontAttributeName,
+                                [NSFont systemFontOfSize:11], NSFontAttributeName,
                                 shadow, NSShadowAttributeName,
                                 [NSColor colorWithDeviceWhite:1.0 alpha:1.0], NSForegroundColorAttributeName,
                                 nil];
@@ -370,7 +370,7 @@ NSString * const OECDBasedGamesUserGuideURLString = @"https://github.com/OpenEmu
     NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
     [style setAlignment:NSCenterTextAlignment];
     NSDictionary *dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:10 size:18.0], NSFontAttributeName,
+                                [NSFont boldSystemFontOfSize:18], NSFontAttributeName,
                                 style, NSParagraphStyleAttributeName,
                                 shadow, NSShadowAttributeName,
                                 [NSColor colorWithDeviceWhite:0.11 alpha:1.0], NSForegroundColorAttributeName,
@@ -384,7 +384,7 @@ NSString * const OECDBasedGamesUserGuideURLString = @"https://github.com/OpenEmu
     [shadow setShadowBlurRadius:2];
 
     dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:
-                  [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:10 size:18.0], NSFontAttributeName,
+                  [NSFont boldSystemFontOfSize:18], NSFontAttributeName,
                   style, NSParagraphStyleAttributeName,
                   shadow, NSShadowAttributeName,
                   [NSColor colorWithDeviceWhite:0.11 alpha:0.0], NSForegroundColorAttributeName,
@@ -500,7 +500,7 @@ NSString * const OECDBasedGamesUserGuideURLString = @"https://github.com/OpenEmu
     [textView setDrawsBackground:NO];
     [textView setEditable:NO];
     [textView setSelectable:NO];
-    [textView setFont:[[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:0 size:11.0]];
+    [textView setFont:[NSFont systemFontOfSize:11]];
     [textView setTextColor:[NSColor colorWithDeviceWhite:0.86 alpha:1.0]];
     [textView setTextContainerInset:NSMakeSize(0, 0)];
 

--- a/OpenEmu/OEControlsKeyButton.m
+++ b/OpenEmu/OEControlsKeyButton.m
@@ -96,7 +96,7 @@
 
     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
     
-    NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:15 size:11.0];
+    NSFont *font = [NSFont boldSystemFontOfSize:11];
     NSShadow *shadow = [[NSShadow alloc] init];
     [shadow setShadowBlurRadius:1.0];
     [shadow setShadowColor:[NSColor colorWithDeviceWhite:1.0 alpha:0.25]];

--- a/OpenEmu/OEControlsKeyHeadlineCell.m
+++ b/OpenEmu/OEControlsKeyHeadlineCell.m
@@ -32,7 +32,7 @@
 {
     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
     
-    NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:0 size:11.5];
+    NSFont *font = [NSFont boldSystemFontOfSize:11.5];
     
     NSShadow *shadow = [[NSShadow alloc] init];
     [shadow setShadowBlurRadius:1.0];

--- a/OpenEmu/OEControlsKeyLabelCell.m
+++ b/OpenEmu/OEControlsKeyLabelCell.m
@@ -54,12 +54,10 @@
 
 - (void)setFontFamily:(NSString *)aFontFamily
 {
-    NSString * const defaultFontFamily = @"Lucida Grande";
-
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
     NSFont *font = [fontManager fontWithFamily:aFontFamily traits:NSFontBoldTrait weight:9.0 size:11.0];
     if(!font) {
-        font = [fontManager fontWithFamily:defaultFontFamily traits:NSFontBoldTrait weight:9.0 size:11.0];
+        font = [NSFont boldSystemFontOfSize:11];
     }
 
     [self setFont:font];

--- a/OpenEmu/OEControlsSectionTitleView.m
+++ b/OpenEmu/OEControlsSectionTitleView.m
@@ -163,7 +163,7 @@ const static CGFloat buttonTitleGap = 5.0;
     dispatch_once(&onceToken, ^{
         NSMutableDictionary *attr = [[NSMutableDictionary alloc] init];
 
-        NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:0 size:11.0];
+        NSFont *font = [NSFont boldSystemFontOfSize:11];
 
         NSShadow *shadow = [[NSShadow alloc] init];
         [shadow setShadowBlurRadius:1.0];

--- a/OpenEmu/OECoreTableButtonCell.m
+++ b/OpenEmu/OECoreTableButtonCell.m
@@ -100,7 +100,7 @@
     if([self isHighlighted])
     {
         textAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
-                                    [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:0.0 size:9.0], NSFontAttributeName,
+                                    [NSFont systemFontOfSize:9], NSFontAttributeName,
                                     [NSColor colorWithDeviceWhite:1.0 alpha:1.0], NSForegroundColorAttributeName,
                                     paraStyle, NSParagraphStyleAttributeName,
                                     shadow, NSShadowAttributeName,
@@ -109,7 +109,7 @@
     else
     {
         textAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
-                          [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:0.0 size:9.0], NSFontAttributeName,
+                          [NSFont systemFontOfSize:9], NSFontAttributeName,
                           [NSColor colorWithDeviceWhite:0.89 alpha:1.0], NSForegroundColorAttributeName,
                           paraStyle, NSParagraphStyleAttributeName,
                           shadow, NSShadowAttributeName,

--- a/OpenEmu/OEGridGameCell.m
+++ b/OpenEmu/OEGridGameCell.m
@@ -314,7 +314,7 @@ static NSDictionary *disabledActions = nil;
     [_foregroundLayer setActions:disabledActions];
 
     // setup title layer
-    NSFont *titleFont = [NSFont labelFontOfSize:[NSFont labelFontSize]];
+    NSFont *titleFont = [NSFont systemFontOfSize:11 weight:NSFontWeightMedium];
     _textLayer = [CATextLayer layer];
     [_textLayer setActions:disabledActions];
 

--- a/OpenEmu/OEGridGameCell.m
+++ b/OpenEmu/OEGridGameCell.m
@@ -314,7 +314,7 @@ static NSDictionary *disabledActions = nil;
     [_foregroundLayer setActions:disabledActions];
 
     // setup title layer
-    NSFont *titleFont = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:9 size:12];
+    NSFont *titleFont = [NSFont boldSystemFontOfSize:12];
     _textLayer = [CATextLayer layer];
     [_textLayer setActions:disabledActions];
 

--- a/OpenEmu/OEGridGameCell.m
+++ b/OpenEmu/OEGridGameCell.m
@@ -314,7 +314,7 @@ static NSDictionary *disabledActions = nil;
     [_foregroundLayer setActions:disabledActions];
 
     // setup title layer
-    NSFont *titleFont = [NSFont boldSystemFontOfSize:12];
+    NSFont *titleFont = [NSFont labelFontOfSize:[NSFont labelFontSize]];
     _textLayer = [CATextLayer layer];
     [_textLayer setActions:disabledActions];
 

--- a/OpenEmu/OEGridMediaGroupItemCell.m
+++ b/OpenEmu/OEGridMediaGroupItemCell.m
@@ -204,7 +204,7 @@ static NSDictionary *disabledActions = nil;
     [_foregroundLayer setCornerRadius:10];
 
     // setup title layer
-    NSFont *titleFont = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:9 size:12];
+    NSFont *titleFont = [NSFont boldSystemFontOfSize:12];
     _textLayer = [CATextLayer layer];
     [_textLayer setActions:disabledActions];
 

--- a/OpenEmu/OEGridMediaItemCell.m
+++ b/OpenEmu/OEGridMediaItemCell.m
@@ -190,7 +190,7 @@ static NSDictionary *disabledActions = nil;
     [_foregroundLayer setActions:disabledActions];
 
     // setup title layer
-    NSFont *titleFont = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:9 size:12];
+    NSFont *titleFont = [NSFont boldSystemFontOfSize:12];
     _textLayer = [CATextLayer layer];
     [_textLayer setActions:disabledActions];
 

--- a/OpenEmu/OEGridViewFieldEditor.m
+++ b/OpenEmu/OEGridViewFieldEditor.m
@@ -51,7 +51,7 @@
         [self setHidden:YES];
         [self setWantsLayer:YES];
 
-        NSFont *fieldEditorFont = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:9 size:12];
+        NSFont *fieldEditorFont = [NSFont boldSystemFontOfSize:12];
         [self setAlignment:NSCenterTextAlignment];
         [self setBorderColor:[NSColor blackColor]];
         [self setFont:fieldEditorFont];

--- a/OpenEmu/OEHUDAlert.m
+++ b/OpenEmu/OEHUDAlert.m
@@ -595,8 +595,8 @@ static const CGFloat _OEHUDAlertMinimumHeadlineLength   = 291.0;
     frame.size = (NSSize){ _OEHUDAlertBoxSideMargin + _OEHUDAlertDefaultBoxWidth + _OEHUDAlertBoxSideMargin, 1 };
     [_hudWindow setFrame:frame display:NO];
 
-    NSFont *defaultFont = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:0 size:11.0];
-    NSFont *boldFont = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:0 size:11.0];
+    NSFont *defaultFont = [NSFont systemFontOfSize:11];
+    NSFont *boldFont = [NSFont boldSystemFontOfSize:11];
 
     NSColor *defaultColor = [NSColor colorWithDeviceWhite:0.859 alpha:1.0];
 

--- a/OpenEmu/OEHUDWindow.m
+++ b/OpenEmu/OEHUDWindow.m
@@ -461,7 +461,7 @@ static NSImage *frameImage, *frameImageInactive;
         [titleAttributes setObject:ps forKey:NSParagraphStyleAttributeName];
 
         NSColor *textColor = isFocused ? [NSColor colorWithDeviceWhite:0.86 alpha:1.0] : [NSColor colorWithDeviceWhite:0.61 alpha:1.0];
-        NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:2.0 size:13.0];
+        NSFont *font = [NSFont systemFontOfSize:13];
         NSShadow *shadow = [[NSShadow alloc] init];
         [shadow setShadowColor:[NSColor colorWithDeviceRed:0.129 green:0.129 blue:0.129 alpha:1.0]];
         [shadow setShadowBlurRadius:1.0];

--- a/OpenEmu/OEPrefCoreSliderLabelCell.m
+++ b/OpenEmu/OEPrefCoreSliderLabelCell.m
@@ -34,7 +34,7 @@
 	NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
 	[paragraphStyle setAlignment:[self alignment]];
 	
-	NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:4.0 size:12.0];
+	NSFont *font = [NSFont boldSystemFontOfSize:12];
 		
 	[attributes setObject:[NSColor colorWithDeviceWhite:0.89 alpha:1.0] forKey:NSForegroundColorAttributeName];
 	[attributes setObject:font forKey:NSFontAttributeName];

--- a/OpenEmu/OEPrefCoresController.m
+++ b/OpenEmu/OEPrefCoresController.m
@@ -154,7 +154,7 @@ static void *const _OEPrefCoresCoreListContext = (void *)&_OEPrefCoresCoreListCo
         [style setLineBreakMode:NSLineBreakByTruncatingTail];
         
         attr = @{
-                 NSFontAttributeName : [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:weight size:11.0],
+                 NSFontAttributeName : [NSFont systemFontOfSize:11],
                  NSForegroundColorAttributeName : color,
                  NSParagraphStyleAttributeName : style
                  };

--- a/OpenEmu/OESetupAssistantTableView.m
+++ b/OpenEmu/OESetupAssistantTableView.m
@@ -156,7 +156,7 @@
 {
 	NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
 	
-	NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:0 size:11.5];
+    NSFont *font = [NSFont boldSystemFontOfSize:11.5];
 	
 	NSShadow *shadow = [[NSShadow alloc] init];
 	[shadow setShadowColor:[NSColor colorWithDeviceWhite:0.0 alpha:1.0]];
@@ -197,7 +197,7 @@
 {
     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
 	
-	NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:0 size:11.0];
+    NSFont *font = [NSFont systemFontOfSize:11];
 	
 	NSShadow *shadow = [[NSShadow alloc] init];
 	[shadow setShadowColor:[NSColor colorWithDeviceWhite:0.0 alpha:1.0]];

--- a/OpenEmu/OESidebarCell.m
+++ b/OpenEmu/OESidebarCell.m
@@ -200,7 +200,7 @@ const CGFloat BadgeSpacing = 2.0;
 {	
 	textObj = [super setUpFieldEditorAttributes:textObj];
 	
-	NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:9 size:11.0];
+    NSFont *font = [NSFont boldSystemFontOfSize:11];
 	NSColor *textColor = [NSColor blackColor];
 	
 	NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
@@ -327,7 +327,7 @@ const CGFloat BadgeSpacing = 2.0;
 
 	if([self isEditing])
     {
-        NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:9 size:11.0];
+        NSFont *font = [NSFont boldSystemFontOfSize:11];
         NSColor *textColor = [NSColor blackColor];
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
         [paragraphStyle setLineBreakMode:NSLineBreakByTruncatingTail];

--- a/OpenEmu/OESidebarCell.m
+++ b/OpenEmu/OESidebarCell.m
@@ -261,10 +261,19 @@ const CGFloat BadgeSpacing = 2.0;
 		titleFrame.origin.y += 9;
 		titleFrame.origin.x -= 8;
 		titleFrame.size.width += 8;
-	}
+        
+        // NOTE: The bold trait specified in "sidebar_group" in Theme.plist doesn't get applied for some reason, so manually set a bold font for group sidebar items. This is a hack, but since NSCell is deprecated, this code will eventually be replaced by a view-based solution anyway.
+        NSMutableDictionary *mutableAttributes = [attributes mutableCopy];
+        mutableAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:11];
+        attributes = mutableAttributes;
+    }
     else
     {
         attributes = [[self itemAttributes] textAttributesForState:state];
+        
+        // Adjust the title frame to fit the system typeface.
+        titleFrame.size.height += 2;
+        titleFrame.origin.y -= 2;
     }
 
 	NSAttributedString *strVal = [[NSAttributedString alloc] initWithString:[self stringValue] attributes:attributes];

--- a/OpenEmu/OESidebarController.m
+++ b/OpenEmu/OESidebarController.m
@@ -90,13 +90,13 @@ NSString * const OEMainViewMinWidth = @"mainViewMinWidth";
 - (void)awakeFromNib
 {
     self.groups = @[
-                    [OESidebarGroupItem groupItemWithName:NSLocalizedString(@"CONSOLES", @"") autosaveName:OESidebarGroupConsolesAutosaveName],
+                    [OESidebarGroupItem groupItemWithName:NSLocalizedString(@"Consoles", @"") autosaveName:OESidebarGroupConsolesAutosaveName],
 
 #define DevicesSectionIndex 1 // keep track of devices section index so we can skip it if no devices are connected
-                    [OESidebarGroupItem groupItemWithName:NSLocalizedString(@"DEVICES", @"") autosaveName:OESidebarGroupDevicesAutosaveName],
+                    [OESidebarGroupItem groupItemWithName:NSLocalizedString(@"Devices", @"") autosaveName:OESidebarGroupDevicesAutosaveName],
 
-                    [OESidebarGroupItem groupItemWithName:NSLocalizedString(@"MEDIA", @"") autosaveName:OESidebarGroupMediaAutosaveName],
-                    [OESidebarGroupItem groupItemWithName:NSLocalizedString(@"COLLECTIONS", @"") autosaveName:OESidebarGroupCollectionsAutosaveName]
+                    [OESidebarGroupItem groupItemWithName:NSLocalizedString(@"Media", @"") autosaveName:OESidebarGroupMediaAutosaveName],
+                    [OESidebarGroupItem groupItemWithName:NSLocalizedString(@"Collections", @"") autosaveName:OESidebarGroupCollectionsAutosaveName]
                     ];
 
     OESidebarOutlineView *sidebarView = (OESidebarOutlineView*)[self view];

--- a/OpenEmu/OETableHeaderCell.m
+++ b/OpenEmu/OETableHeaderCell.m
@@ -124,7 +124,7 @@ static const CGFloat _OESortIndicatorMargin = 5;
     const NSInteger priority         = ([[sortDescriptor key] isEqualToString:[[tableColumn sortDescriptorPrototype] key]] ? 1 : 0);
 
 
-	NSFont *titleFont = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:4 size:11];
+    NSFont *titleFont = [NSFont boldSystemFontOfSize:11];
 	NSMutableParagraphStyle *paraStyle = [[NSMutableParagraphStyle alloc] init];
 	[paraStyle setLineBreakMode:NSLineBreakByTruncatingTail];
     [paraStyle setAlignment:[self alignment]];

--- a/OpenEmu/OETableView.m
+++ b/OpenEmu/OETableView.m
@@ -109,7 +109,7 @@ static NSGradient *highlightGradient, *normalGradient;
     for (NSTableColumn *aColumn in [self tableColumns])
     {
         OETableHeaderCell *newHeader = [[OETableHeaderCell alloc] initTextCell:[[aColumn headerCell] stringValue]];
-        [newHeader setFont:[[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:NSBoldFontMask weight:9 size:11]];
+        [newHeader setFont:[NSFont boldSystemFontOfSize:11]];
         [aColumn setHeaderCell: newHeader];
     }
 

--- a/OpenEmu/OEToolbarView.m
+++ b/OpenEmu/OEToolbarView.m
@@ -118,7 +118,7 @@
     float imageSideLength = 36;
     float imageTitleSpacing = 4;
 
-    NSFont *font = [[NSFontManager sharedFontManager] fontWithFamily:@"Lucida Grande" traits:0 weight:4.0 size:11.0];
+    NSFont *font = [NSFont systemFontOfSize:11];
     NSColor *textColor = [NSColor blackColor];
     NSShadow *shadow = [[NSShadow alloc] init];
     [shadow setShadowColor:[NSColor colorWithDeviceWhite:1.0 alpha:0.45]];

--- a/OpenEmu/en.lproj/MainMenu.xib
+++ b/OpenEmu/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9058" systemVersion="15A282b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9058"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -30,7 +30,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="400" height="463"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <animations/>
-                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" image="3600EC4C-DDEF-497C-9FC7-E6F10A80AB20" id="804"/>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" image="55155152-D468-467D-8216-96BCDD936500" id="804"/>
                     </imageView>
                     <textField verticalHuggingPriority="750" id="796">
                         <rect key="frame" x="17" y="184" width="366" height="18"/>
@@ -98,7 +98,7 @@ documentation, licenses and to issue
 bugs please visit us on our GitHub. </string>
                                             <attributes>
                                                 <color key="NSColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <font key="NSFont" size="11" name="LucidaGrande"/>
+                                                <font key="NSFont" metaFont="smallSystem"/>
                                                 <real key="NSKern" value="0.0"/>
                                                 <integer key="NSLigature" value="0"/>
                                                 <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineHeightMultiple="1.2249999999999999"/>
@@ -648,7 +648,7 @@ DQ
         <userDefaultsController representsSharedInstance="YES" id="1212"/>
     </objects>
     <resources>
-        <image name="3600EC4C-DDEF-497C-9FC7-E6F10A80AB20" width="400" height="463">
+        <image name="55155152-D468-467D-8216-96BCDD936500" width="400" height="463">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGOjtYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK0HCBEW
 GxwgISgrLjQ3VSRudWxs1AkKCwwNDg8QViRjbGFzc1xOU0ltYWdlRmxhZ3NWTlNSZXBzV05TQ29sb3KA


### PR DESCRIPTION
Use the El Capitan system typeface in the UI instead of Lucida Grande. The changes are primarily a combination of Theme.plist changes and calls to the NSFont +systemFont.../+boldSystemFont... family of methods.

Note: Sidebar group items weren't recognizing the bold trait specified in "sidebar_group" in Theme.plist, so group item cells are manually made bold to match the El Capitan sidebar style. The justification for this workaround is that NSCell is deprecated, so a view-based sidebar will eventually replace the code anyway.

![screen shot 2015-10-17 at 5 43 49 pm](https://cloud.githubusercontent.com/assets/238567/10561805/102ebdd2-74f8-11e5-9d5c-f5abd51c7e1f.jpg)
![screen shot 2015-10-17 at 5 37 22 pm](https://cloud.githubusercontent.com/assets/238567/10561807/1a0b0c34-74f8-11e5-92c8-2270ffc403dc.jpg)
![screen shot 2015-10-17 at 5 37 35 pm](https://cloud.githubusercontent.com/assets/238567/10561809/294d49b4-74f8-11e5-9b64-433675bb1306.jpg)
![screen shot 2015-10-17 at 5 37 30 pm](https://cloud.githubusercontent.com/assets/238567/10561815/66edf1c4-74f8-11e5-9890-fe2cbbee9b61.jpg)
