### PR TITLE
Add system font tokens to Theme.plist and "flatten" grid view.

### DIFF
--- a/Interface Graphics/Theme.plist
+++ b/Interface Graphics/Theme.plist
@@ -24,7 +24,7 @@
 		<key>about_github_link</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -58,7 +58,7 @@
 		<key>about_website_link</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -94,7 +94,7 @@
 		<key>dark_button</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -106,6 +106,8 @@
 			</dict>
 			<key>Size</key>
 			<integer>11</integer>
+			<key>Weight</key>
+			<real>0.2</real>
 			<key>States</key>
 			<dict>
 				<key>Default</key>
@@ -119,13 +121,11 @@
 					<string>rgb(188,188,188,1.0)</string>
 				</dict>
 			</dict>
-			<key>Traits</key>
-			<string>Bold</string>
 		</dict>
 		<key>dark_button_small</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -137,6 +137,8 @@
 			</dict>
 			<key>Size</key>
 			<integer>9</integer>
+			<key>Weight</key>
+			<real>0.2</real>
 			<key>States</key>
 			<dict>
 				<key>Default</key>
@@ -150,13 +152,11 @@
 					<string>rgb(188,188,188,1.0)</string>
 				</dict>
 			</dict>
-			<key>Traits</key>
-			<string>Bold</string>
 		</dict>
 		<key>dark_checkbox</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -181,17 +181,15 @@
 					<string>gray</string>
 				</dict>
 			</dict>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>0</integer>
+			<real>0.2</real>
 		</dict>
 		<key>dark_menu_item</key>
 		<dict>
 			<key>Color</key>
 			<string>white</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>States</key>
@@ -217,17 +215,15 @@
 					<string>white</string>
 				</dict>
 			</dict>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>11</integer>
+			<real>0.2</real>
 		</dict>
 		<key>dark_popup_button</key>
 		<dict>
 			<key>Color</key>
 			<string>rgb(227,227,227)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -239,13 +235,13 @@
 			</dict>
 			<key>Size</key>
 			<integer>11</integer>
-			<key>Traits</key>
-			<string>Bold</string>
+			<key>Weight</key>
+			<real>0.2</real>
 		</dict>
 		<key>game_scanner_fix_issues</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>States</key>
@@ -290,7 +286,7 @@
 			<key>Color</key>
 			<string>rgba(174,173,173,1.0)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -312,7 +308,7 @@
 			<key>Color</key>
 			<string>white</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -334,7 +330,7 @@
 			<key>Color</key>
 			<string>rgb(184, 184, 184)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -358,7 +354,7 @@
 			<key>Color</key>
 			<string>rgba(174,173,173,1.0)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -380,7 +376,7 @@
 			<key>Color</key>
 			<string>rgba(156,156,156,1.0)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -398,7 +394,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -455,7 +451,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -512,7 +508,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -557,7 +553,7 @@
 			<key>Color</key>
 			<string>rgb(227,227,227)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -577,7 +573,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -618,7 +614,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -659,7 +655,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -698,7 +694,7 @@
 		<key>hud_checkbox</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -733,7 +729,7 @@
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -778,7 +774,7 @@
 			<key>Color</key>
 			<string>#dbdbdb</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>Traits</key>
@@ -793,7 +789,7 @@
 			<key>Color</key>
 			<string>#f2f2f2</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>Traits</key>
@@ -808,7 +804,7 @@
 			<key>Color</key>
 			<string>black</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>Traits</key>
@@ -821,7 +817,7 @@
 			<key>Color</key>
 			<string>black</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>States</key>
@@ -847,15 +843,13 @@
 					<string>white</string>
 				</dict>
 			</dict>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>11</integer>
+			<real>0.2</real>
 		</dict>
 		<key>open_weblink</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
 			<integer>11</integer>
 			<key>States</key>
@@ -909,7 +903,7 @@
 			<key>Color</key>
 			<string>rgb(245,245,245)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -923,15 +917,13 @@
 			<integer>11</integer>
 			<key>Traits</key>
 			<string>Bold</string>
-			<key>Weight</key>
-			<integer>8</integer>
 		</dict>
 		<key>bios_main</key>
 		<dict>
 			<key>Color</key>
 			<string>rgb(245,245,245)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -943,17 +935,15 @@
 			</dict>
 			<key>Size</key>
 			<integer>11</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>8</integer>
+			<real>0.5</real>
 		</dict>
 		<key>bios_info</key>
 		<dict>
 			<key>Color</key>
 			<string>rgb(245,245,245)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -968,14 +958,14 @@
 			<key>Traits</key>
 			<string>Regular</string>
 			<key>Weight</key>
-			<integer>4</integer>
+			<integer>0</integer>
 		</dict>
 		<key>bios_info_link</key>
 		<dict>
 			<key>Color</key>
 			<string>#526ba0</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -987,17 +977,15 @@
 			</dict>
 			<key>Size</key>
 			<integer>12</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>4</integer>
+			<integer>0</integer>
 		</dict>
 		<key>bios_sub</key>
 		<dict>
 			<key>Color</key>
 			<string>rgb(215,215,215)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1012,14 +1000,14 @@
 			<key>Traits</key>
 			<string>Regular</string>
 			<key>Weight</key>
-			<integer>4</integer>
+			<real>0.2</real>
 		</dict>
 		<key>bios_group</key>
 		<dict>
 			<key>Color</key>
 			<string>#d9d9d9</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1031,17 +1019,15 @@
 			</dict>
 			<key>Size</key>
 			<integer>11</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>4</integer>
+			<real>0.2</real>
 		</dict>
 		<key>preferences_text</key>
 		<dict>
 			<key>Color</key>
 			<string>rgb(227,227,227)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1053,17 +1039,15 @@
 			</dict>
 			<key>Size</key>
 			<integer>11</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<real>4</real>
+			<real>0.2</real>
 		</dict>
 		<key>preferences_wood_text</key>
 		<dict>
 			<key>Color</key>
 			<string>black</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1075,15 +1059,13 @@
 			</dict>
 			<key>Size</key>
 			<integer>11</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>8</integer>
+			<real>0.2</real>
 		</dict>
 		<key>search_field</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1118,17 +1100,15 @@
 					<string>#545454</string>
 				</dict>
 			</dict>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>3</integer>
+			<real>0.2</real>
 		</dict>
 		<key>search_field_selection</key>
 		<dict>
 			<key>Background Color</key>
 			<string>#808080</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1168,17 +1148,15 @@
 					<string>#545454</string>
 				</dict>
 			</dict>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>3</integer>
+			<real>0.2</real>
 		</dict>
 		<key>wood_popup_button</key>
 		<dict>
 			<key>Color</key>
 			<string>black</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1190,17 +1168,15 @@
 			</dict>
 			<key>Size</key>
 			<integer>11</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<string>11.0</string>
+			<string>0.4</string>
 		</dict>
 		<key>homebrew_headline</key>
 		<dict>
 			<key>Color</key>
 			<string>#eff3fd</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1212,17 +1188,15 @@
 			</dict>
 			<key>Size</key>
 			<integer>18</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>8</integer>
+			<real>0.2</real>
 		</dict>
 		<key>homebrew_gamename</key>
 		<dict>
 			<key>Color</key>
 			<string>#eff3fd</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1234,17 +1208,15 @@
 			</dict>
 			<key>Size</key>
 			<integer>16</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>8</integer>
+			<real>0.2</real>
 		</dict>
 		<key>feature_gamename</key>
 		<dict>
 			<key>Color</key>
 			<string>#eff3fd</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1256,17 +1228,15 @@
 			</dict>
 			<key>Size</key>
 			<integer>14</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>8</integer>
+			<real>0.1</real>
 		</dict>
 		<key>homebrew_text</key>
 		<dict>
 			<key>Color</key>
 			<string>#929DA5</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1278,13 +1248,15 @@
 			</dict>
 			<key>Size</key>
 			<integer>14</integer>
+			<key>Weight</key>
+			<real>0.2</real>
 		</dict>
 		<key>homebrew_description</key>
 		<dict>
 			<key>Color</key>
 			<string>rgba(127,127,127,1.0)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1296,15 +1268,19 @@
 			</dict>
 			<key>Size</key>
 			<integer>12</integer>
+			<key>Weight</key>
+			<real>0.2</real>
 			<key>Alignment</key>
 			<string>Justify</string>
 		</dict>
 		<key>homebrew_developer</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
 			<integer>14</integer>
+			<key>Weight</key>
+			<string>0.2</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1338,7 +1314,7 @@
 			<key>Color</key>
 			<string>rgba(127,127,127,1.0)</string>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Shadow</key>
 			<dict>
 				<key>Blur Radius</key>
@@ -1350,91 +1326,53 @@
 			</dict>
 			<key>Size</key>
 			<integer>12</integer>
+			<key>Weight</key>
+			<real>0.2</real>
 		</dict>
 		<key>sidebar_group</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
-			<key>Shadow</key>
-			<dict>
-				<key>Blur Radius</key>
-				<integer>1</integer>
-				<key>Color</key>
-				<string>rgba(0,0,0,1)</string>
-				<key>Offset</key>
-				<string>{0,1}</string>
-			</dict>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
 			<integer>11</integer>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Color</key>
 			<string>rgba(153, 153, 153, 1.0)</string>
 			<key>Weight</key>
-			<integer>3</integer>
+			<integer>1</integer>
 		</dict>
 		<key>sidebar_item</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
-			<integer>11</integer>
+			<integer>12</integer>
 			<key>States</key>
 			<dict>
 				<key>Unfocused</key>
 				<dict>
-					<key>Shadow</key>
-					<dict>
-						<key>Blur Radius</key>
-						<integer>1</integer>
-						<key>Color</key>
-						<string>rgba(0,0,0,1)</string>
-						<key>Offset</key>
-						<string>{0,-1}</string>
-					</dict>
 					<key>Color</key>
 					<string>rgba(225, 224, 224, 1.0)</string>
 				</dict>
 				<key>Window Active, Focused</key>
 				<dict>
-					<key>Shadow</key>
-					<dict>
-						<key>Blur Radius</key>
-						<integer>1</integer>
-						<key>Color</key>
-						<string>rgba(0,0,0,1)</string>
-						<key>Offset</key>
-						<string>{0,-1}</string>
-					</dict>
 					<key>Color</key>
 					<string>white</string>
 				</dict>
 				<key>Window Inactive, Focused</key>
 				<dict>
-					<key>Shadow</key>
-					<dict>
-						<key>Blur Radius</key>
-						<integer>1</integer>
-						<key>Color</key>
-						<string>rgba(153,153,153,1)</string>
-						<key>Offset</key>
-						<string>{0,-1}</string>
-					</dict>
 					<key>Color</key>
 					<string>rgba(36,36,36,1.0)</string>
 				</dict>
 			</dict>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>3</integer>
+			<real>0.1</real>
 			<key>Line Break</key>
 			<string>Truncate Tail</string>
 		</dict>
 		<key>sidebar_item_badge</key>
 		<dict>
 			<key>Family</key>
-			<string>San Francisco</string>
+			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Alignment</key>
 			<string>Center</string>
 			<key>Shadow</key>
@@ -1471,10 +1409,8 @@
 					<string>#545454</string>
 				</dict>
 			</dict>
-			<key>Traits</key>
-			<string>Bold</string>
 			<key>Weight</key>
-			<integer>3</integer>
+			<real>0.3</real>
 		</dict>
 	</dict>
 	<key>Gradients</key>

--- a/Interface Graphics/Theme.plist
+++ b/Interface Graphics/Theme.plist
@@ -1345,7 +1345,7 @@
 			<key>Family</key>
 			<string>$SYSTEM_FONT_FAMILY</string>
 			<key>Size</key>
-			<integer>12</integer>
+			<integer>13</integer>
 			<key>States</key>
 			<dict>
 				<key>Unfocused</key>

--- a/OpenEmu/OEGridGameCell.h
+++ b/OpenEmu/OEGridGameCell.h
@@ -10,7 +10,6 @@
 #import "OEGridView.h"
 #import "OEGridCell.h"
 
-extern NSString *const OECoverGridViewGlossDisabledKey;
 @interface OEGridGameCell : OEGridCell
 + (NSImage *)missingArtworkImageWithSize:(NSSize)size;
 - (NSImage *)missingArtworkImageWithSize:(NSSize)size;

--- a/OpenEmu/OEGridGameCell.m
+++ b/OpenEmu/OEGridGameCell.m
@@ -21,7 +21,6 @@ static const CGFloat OEGridCellTitleHeight                      = 16.0;        /
 static const CGFloat OEGridCellImageTitleSpacing                = 17.0;        // Space between the image and the title
 static const CGFloat OEGridCellSubtitleHeight                   = 11.0;        // Subtitle height
 static const CGFloat OEGridCellSubtitleWidth                    = 56.0;        // Subtitle's width
-static const CGFloat OEGridCellGlossWidthToHeightRatio          = 0.6442;      // Gloss image's width to height ratio
 
 static const CGFloat OEGridCellImageContainerLeft   = 13.0;
 static const CGFloat OEGridCellImageContainerTop    = 7.0;
@@ -38,7 +37,6 @@ __strong static OEThemeImage *selectorRingImage = nil;
 @property CALayer     *foregroundLayer;
 @property CATextLayer *textLayer;
 @property CALayer     *ratingLayer;
-@property CALayer     *glossyLayer;
 @property CALayer     *backgroundLayer;
 @property CALayer     *missingArtworkLayer;
 @property CALayer     *downloadLayer;
@@ -314,7 +312,8 @@ static NSDictionary *disabledActions = nil;
     [_foregroundLayer setActions:disabledActions];
 
     // setup title layer
-    NSFont *titleFont = [NSFont systemFontOfSize:11 weight:NSFontWeightMedium];
+    const CGFloat titleFontSize = [NSFont systemFontSize];
+    NSFont *titleFont = [NSFont systemFontOfSize:titleFontSize weight:NSFontWeightMedium];
     _textLayer = [CATextLayer layer];
     [_textLayer setActions:disabledActions];
 
@@ -322,12 +321,8 @@ static NSDictionary *disabledActions = nil;
     [_textLayer setTruncationMode:kCATruncationEnd];
     [_textLayer setForegroundColor:[[NSColor whiteColor] CGColor]];
     [_textLayer setFont:(__bridge CTFontRef)titleFont];
-    [_textLayer setFontSize:12.0];
+    [_textLayer setFontSize:titleFontSize];
 
-    [_textLayer setShadowColor:[[NSColor blackColor] CGColor]];
-    [_textLayer setShadowOffset:CGSizeMake(0.0, -1.0)];
-    [_textLayer setShadowRadius:1.0];
-    [_textLayer setShadowOpacity:1.0];
     [_foregroundLayer addSublayer:_textLayer];
 
     // setup rating layer
@@ -339,11 +334,6 @@ static NSDictionary *disabledActions = nil;
     [_missingArtworkLayer setActions:disabledActions];
     [_foregroundLayer addSublayer:_missingArtworkLayer];
 
-    // setup gloss layer
-    _glossyLayer = [CALayer layer];
-    [_glossyLayer setActions:disabledActions];
-    [_foregroundLayer addSublayer:_glossyLayer];
-
     _indicationLayer = [[OEGridViewCellIndicationLayer alloc] init];
     [_indicationLayer setType:OEGridViewCellIndicationTypeNone];
     [_foregroundLayer addSublayer:_indicationLayer];
@@ -352,8 +342,8 @@ static NSDictionary *disabledActions = nil;
     _backgroundLayer = [CALayer layer];
     [_backgroundLayer setActions:disabledActions];
     [_backgroundLayer setShadowColor:[[NSColor blackColor] CGColor]];
-    [_backgroundLayer setShadowOffset:CGSizeMake(0.0, -3.0)];
-    [_backgroundLayer setShadowRadius:3.0];
+    [_backgroundLayer setShadowOffset:CGSizeMake(0.0, -2.0)];
+    [_backgroundLayer setShadowRadius:2.0];
     [_backgroundLayer setContentsGravity:kCAGravityResize];
 
     _downloadButtonState = OEThemeStateDefault;
@@ -428,15 +418,8 @@ static NSDictionary *disabledActions = nil;
         [_ratingLayer setFrame:relativeRatingFrame];
         [_ratingLayer setContents:ratingImage];
 
-		// add a glossy overlay if image is loaded
         if(state == IKImageStateReady)
         {
-            NSImage *glossyImage = [self OE_glossImageWithSize:relativeImageFrame.size];
-            [_glossyLayer setContentsScale:scaleFactor];
-            [_glossyLayer setFrame:relativeImageFrame];
-            [_glossyLayer setContents:glossyImage];
-            [_glossyLayer setHidden:NO];
-
             if([identifier characterAtIndex:0]==':' && !NSEqualSizes(relativeImageFrame.size, _lastImageSize))
             {
                 NSImage *missingArtworkImage = [self missingArtworkImageWithSize:relativeImageFrame.size];
@@ -456,7 +439,6 @@ static NSDictionary *disabledActions = nil;
         }
         else
         {
-            [_glossyLayer setHidden:YES];
             [_proposedImageLayer removeFromSuperlayer];
             [_indicationLayer setType:OEGridViewCellIndicationTypeNone];
         }
@@ -497,7 +479,6 @@ static NSDictionary *disabledActions = nil;
                 _downloadLayer = [CALayer layer];
                 [_downloadLayer setContentsGravity:kCAGravityResizeAspect];
                 [_downloadLayer setActions:disabledActions];
-                [[_glossyLayer superlayer] insertSublayer:_downloadLayer below:_glossyLayer];
             }
 
             OEThemeImage *image = [[OETheme sharedTheme] themeImageForKey:@"grid_download"];
@@ -604,55 +585,6 @@ static NSDictionary *disabledActions = nil;
 {
     // TODO: why do we use the background layer?
     [[[self imageBrowserView] backgroundLayer] setValue:image forKey:name];
-}
-
-- (NSImage *)OE_glossImageWithSize:(NSSize)size
-{
-    if([[NSUserDefaults standardUserDefaults] boolForKey:OECoverGridViewGlossDisabledKey]) return nil;
-    if(NSEqualSizes(size, NSZeroSize)) return nil;
-
-    static NSCache *cache = nil;
-    if(cache == nil)
-    {
-        cache = [[NSCache alloc] init];
-        [cache setCountLimit:30];
-    }
-
-    NSString *key = NSStringFromSize(size);
-    NSImage *glossImage = [cache objectForKey:key];
-    if(glossImage) return glossImage;
-
-    BOOL(^drawingBlock)(NSRect) = ^BOOL(NSRect dstRect)
-    {
-        NSGraphicsContext *currentContext = [NSGraphicsContext currentContext];
-
-        // Draw gloss image fit proportionally within the cell
-        NSImage *boxGlossImage = [NSImage imageNamed:@"box_gloss"];
-        CGRect   boxGlossFrame = CGRectMake(0.0, 0.0, size.width, floor(size.width * OEGridCellGlossWidthToHeightRatio));
-        boxGlossFrame.origin.y = size.height - CGRectGetHeight(boxGlossFrame);
-        [boxGlossImage drawInRect:boxGlossFrame fromRect:NSZeroRect operation:NSCompositeCopy fraction:1.0];
-
-        [currentContext saveGraphicsState];
-        [currentContext setShouldAntialias:YES];
-
-        const NSRect bounds = NSMakeRect(0.0, 0.0, size.width-0.5, size.height-0.5);
-        [[NSColor colorWithCalibratedWhite:1.0 alpha:0.4] setStroke];
-        [[NSBezierPath bezierPathWithRect:NSOffsetRect(bounds, 0.0, -1.0)] stroke];
-
-        [[NSColor blackColor] setStroke];
-        NSBezierPath *path = [NSBezierPath bezierPathWithRect:bounds];
-        [path stroke];
-
-        [currentContext restoreGraphicsState];
-
-        return YES;
-    };
-
-    glossImage = [NSImage imageWithSize:size flipped:NO drawingHandler:drawingBlock];
-
-    [cache setObject:glossImage forKey:key cost:size.height*size.width];
-
-    return glossImage;
 }
 
 - (NSImage *)missingArtworkImageWithSize:(NSSize)size

--- a/OpenEmu/OEGridMediaGroupItemCell.m
+++ b/OpenEmu/OEGridMediaGroupItemCell.m
@@ -41,7 +41,6 @@ static const CGFloat OEGridCellTitleHeight                      = 16.0;        /
 static const CGFloat OEGridCellImageTitleSpacing                = 17.0;        // Space between the image and the title
 static const CGFloat OEGridCellSubtitleHeight                   = 11.0;        // Subtitle height
 __unused static const CGFloat OEGridCellSubtitleWidth                    = 56.0;        // Subtitle's width
-static const CGFloat OEGridCellGlossWidthToHeightRatio          = 0.6442;      // Gloss image's width to height ratio
 
 static const CGFloat OEGridCellImageContainerLeft   = 13.0;
 static const CGFloat OEGridCellImageContainerTop    = 7.0;
@@ -50,8 +49,6 @@ static const CGFloat OEGridCellImageContainerBottom = OEGridCellTitleHeight + OE
 
 __strong static OEThemeImage *selectorRingImage = nil;
 
-extern NSString *const OECoverGridViewGlossDisabledKey;
-
 @interface OEGridMediaGroupItemCell ()
 @property NSImage *selectorImage;
 @property CALayer *selectionLayer;
@@ -59,7 +56,6 @@ extern NSString *const OECoverGridViewGlossDisabledKey;
 @property CALayer     *foregroundLayer;
 @property CATextLayer *textLayer;
 @property CATextLayer *subtextLayer;
-@property CALayer     *glossyLayer;
 @property CALayer     *backgroundLayer;
 
 @property BOOL    lastWindowActive;
@@ -235,12 +231,6 @@ static NSDictionary *disabledActions = nil;
     [_subtextLayer setShadowOpacity:1.0];
     [_foregroundLayer addSublayer:_subtextLayer];
 
-    // setup gloss layer
-    _glossyLayer = [CALayer layer];
-    [_glossyLayer setActions:disabledActions];
-    [_glossyLayer setCornerRadius:10];
-    [_foregroundLayer addSublayer:_glossyLayer];
-
     // setup background layer
     _backgroundLayer = [CALayer layer];
     [_backgroundLayer setActions:disabledActions];
@@ -314,20 +304,6 @@ static NSDictionary *disabledActions = nil;
         [_subtextLayer setContentsScale:scaleFactor];
         [_subtextLayer setFrame:relativeSubtitleFrame];
         [_subtextLayer setString:subTitle];
-
-		// add a glossy overlay if image is loaded
-        if(state == IKImageStateReady)
-        {
-            NSImage *glossyImage = [self OE_glossImageWithSize:relativeImageFrame.size];
-            [_glossyLayer setContentsScale:scaleFactor];
-            [_glossyLayer setFrame:relativeImageFrame];
-            [_glossyLayer setContents:glossyImage];
-            [_glossyLayer setHidden:NO];
-        }
-        else
-        {
-            [_glossyLayer setHidden:YES];
-        }
 
         // the selection layer is cached else the CATransition initialization fires the layers to be redrawn which causes the CATransition to be initalized again: loop
         if(! CGRectEqualToRect([_selectionLayer frame], CGRectInset(relativeImageFrame, -6.0, -6.0)) || windowActive != _lastWindowActive)
@@ -412,56 +388,6 @@ static NSDictionary *disabledActions = nil;
     // TODO: why do we use the background layer?
     [[[self imageBrowserView] backgroundLayer] setValue:image forKey:name];
 }
-
-- (NSImage *)OE_glossImageWithSize:(NSSize)size
-{
-    if([[NSUserDefaults standardUserDefaults] boolForKey:OECoverGridViewGlossDisabledKey]) return nil;
-    if(NSEqualSizes(size, NSZeroSize)) return nil;
-
-    static NSCache *cache = nil;
-    if(cache == nil)
-    {
-        cache = [[NSCache alloc] init];
-        [cache setCountLimit:30];
-    }
-
-    NSString *key = NSStringFromSize(size);
-    NSImage *glossImage = [cache objectForKey:key];
-    if(glossImage) return glossImage;
-
-    BOOL(^drawingBlock)(NSRect) = ^BOOL(NSRect dstRect)
-    {
-        NSGraphicsContext *currentContext = [NSGraphicsContext currentContext];
-
-        // Draw gloss image fit proportionally within the cell
-        NSImage *boxGlossImage = [NSImage imageNamed:@"box_gloss"];
-        CGRect   boxGlossFrame = CGRectMake(0.0, 0.0, size.width, floor(size.width * OEGridCellGlossWidthToHeightRatio));
-        boxGlossFrame.origin.y = size.height - CGRectGetHeight(boxGlossFrame);
-        [boxGlossImage drawInRect:boxGlossFrame fromRect:NSZeroRect operation:NSCompositeCopy fraction:1.0];
-
-        [currentContext saveGraphicsState];
-        [currentContext setShouldAntialias:YES];
-
-        const NSRect bounds = NSMakeRect(0.0, 0.0, size.width-0.5, size.height-0.5);
-        [[NSColor colorWithCalibratedWhite:1.0 alpha:0.4] setStroke];
-        [[NSBezierPath bezierPathWithRect:NSOffsetRect(bounds, 0.0, -1.0)] stroke];
-
-        [[NSColor blackColor] setStroke];
-        NSBezierPath *path = [NSBezierPath bezierPathWithRect:bounds];
-        [path stroke];
-
-        [currentContext restoreGraphicsState];
-
-        return YES;
-    };
-
-    glossImage = [NSImage imageWithSize:size flipped:NO drawingHandler:drawingBlock];
-
-    [cache setObject:glossImage forKey:key cost:size.height*size.width];
-
-    return glossImage;
-}
-
 
 - (NSImage *)OE_selectorImageWithSize:(NSSize)size
 {

--- a/OpenEmu/OEGridMediaItemCell.m
+++ b/OpenEmu/OEGridMediaItemCell.m
@@ -35,7 +35,6 @@ static const CGFloat OEGridCellTitleHeight                      = 16.0;        /
 static const CGFloat OEGridCellImageTitleSpacing                = 17.0;        // Space between the image and the title
 static const CGFloat OEGridCellSubtitleHeight                   = 11.0;        // Subtitle height
 __unused static const CGFloat OEGridCellSubtitleWidth                    = 56.0;        // Subtitle's width
-static const CGFloat OEGridCellGlossWidthToHeightRatio          = 0.6442;      // Gloss image's width to height ratio
 
 static const CGFloat OEGridCellImageContainerLeft   = 13.0;
 static const CGFloat OEGridCellImageContainerTop    = 7.0;
@@ -44,8 +43,6 @@ static const CGFloat OEGridCellImageContainerBottom = OEGridCellTitleHeight + OE
 
 __strong static OEThemeImage *selectorRingImage = nil;
 
-extern NSString *const OECoverGridViewGlossDisabledKey;
-
 @interface OEGridMediaItemCell ()
 @property NSImage *selectorImage;
 @property CALayer *selectionLayer;
@@ -53,7 +50,6 @@ extern NSString *const OECoverGridViewGlossDisabledKey;
 @property CALayer     *foregroundLayer;
 @property CATextLayer *textLayer;
 @property CATextLayer *subtextLayer;
-@property CALayer     *glossyLayer;
 @property CALayer     *backgroundLayer;
 
 @property BOOL    lastWindowActive;
@@ -221,11 +217,6 @@ static NSDictionary *disabledActions = nil;
     [_subtextLayer setShadowOpacity:1.0];
     [_foregroundLayer addSublayer:_subtextLayer];
 
-    // setup gloss layer
-    _glossyLayer = [CALayer layer];
-    [_glossyLayer setActions:disabledActions];
-    [_foregroundLayer addSublayer:_glossyLayer];
-
     // setup background layer
     _backgroundLayer = [CALayer layer];
     [_backgroundLayer setActions:disabledActions];
@@ -298,20 +289,6 @@ static NSDictionary *disabledActions = nil;
         [_subtextLayer setContentsScale:scaleFactor];
         [_subtextLayer setFrame:relativeSubtitleFrame];
         [_subtextLayer setString:subTitle];
-
-		// add a glossy overlay if image is loaded
-        if(state == IKImageStateReady)
-        {
-            NSImage *glossyImage = [self OE_glossImageWithSize:relativeImageFrame.size];
-            [_glossyLayer setContentsScale:scaleFactor];
-            [_glossyLayer setFrame:relativeImageFrame];
-            [_glossyLayer setContents:glossyImage];
-            [_glossyLayer setHidden:NO];
-        }
-        else
-        {
-            [_glossyLayer setHidden:YES];
-        }
 
         // the selection layer is cached else the CATransition initialization fires the layers to be redrawn which causes the CATransition to be initalized again: loop
         if(! CGRectEqualToRect([_selectionLayer frame], CGRectInset(relativeImageFrame, -6.0, -6.0)) || windowActive != _lastWindowActive)
@@ -396,56 +373,6 @@ static NSDictionary *disabledActions = nil;
     // TODO: why do we use the background layer?
     [[[self imageBrowserView] backgroundLayer] setValue:image forKey:name];
 }
-
-- (NSImage *)OE_glossImageWithSize:(NSSize)size
-{
-    if([[NSUserDefaults standardUserDefaults] boolForKey:OECoverGridViewGlossDisabledKey]) return nil;
-    if(NSEqualSizes(size, NSZeroSize)) return nil;
-
-    static NSCache *cache = nil;
-    if(cache == nil)
-    {
-        cache = [[NSCache alloc] init];
-        [cache setCountLimit:30];
-    }
-
-    NSString *key = NSStringFromSize(size);
-    NSImage *glossImage = [cache objectForKey:key];
-    if(glossImage) return glossImage;
-
-    BOOL(^drawingBlock)(NSRect) = ^BOOL(NSRect dstRect)
-    {
-        NSGraphicsContext *currentContext = [NSGraphicsContext currentContext];
-
-        // Draw gloss image fit proportionally within the cell
-        NSImage *boxGlossImage = [NSImage imageNamed:@"box_gloss"];
-        CGRect   boxGlossFrame = CGRectMake(0.0, 0.0, size.width, floor(size.width * OEGridCellGlossWidthToHeightRatio));
-        boxGlossFrame.origin.y = size.height - CGRectGetHeight(boxGlossFrame);
-        [boxGlossImage drawInRect:boxGlossFrame fromRect:NSZeroRect operation:NSCompositeCopy fraction:1.0];
-
-        [currentContext saveGraphicsState];
-        [currentContext setShouldAntialias:YES];
-
-        const NSRect bounds = NSMakeRect(0.0, 0.0, size.width-0.5, size.height-0.5);
-        [[NSColor colorWithCalibratedWhite:1.0 alpha:0.4] setStroke];
-        [[NSBezierPath bezierPathWithRect:NSOffsetRect(bounds, 0.0, -1.0)] stroke];
-
-        [[NSColor blackColor] setStroke];
-        NSBezierPath *path = [NSBezierPath bezierPathWithRect:bounds];
-        [path stroke];
-
-        [currentContext restoreGraphicsState];
-
-        return YES;
-    };
-
-    glossImage = [NSImage imageWithSize:size flipped:NO drawingHandler:drawingBlock];
-
-    [cache setObject:glossImage forKey:key cost:size.height*size.width];
-
-    return glossImage;
-}
-
 
 - (NSImage *)OE_selectorImageWithSize:(NSSize)size
 {

--- a/OpenEmu/OEGridView.h
+++ b/OpenEmu/OEGridView.h
@@ -29,7 +29,6 @@
 
 extern NSSize const defaultGridSize;
 extern NSString * const OEImageBrowserGroupSubtitleKey;
-extern NSString *const OECoverGridViewGlossDisabledKey;
 
 typedef enum
 {

--- a/OpenEmu/OEGridView.m
+++ b/OpenEmu/OEGridView.m
@@ -32,7 +32,6 @@
 
 #import "OEGridGameCell.h"
 #import "OEGridViewFieldEditor.h"
-#import "OEBackgroundNoisePattern.h"
 #import "OECoverGridDataSourceItem.h"
 
 #import "OEMenu.h"
@@ -47,7 +46,6 @@
 #pragma mark -
 NSSize const defaultGridSize = (NSSize){26+142, 143};
 NSString *const OEImageBrowserGroupSubtitleKey = @"OEImageBrowserGroupSubtitleKey";
-NSString *const OECoverGridViewGlossDisabledKey = @"OECoverGridViewGlossDisabledKey";
 
 @implementation IKCGRenderer (ScaleFactorAdditions)
 - (unsigned long long)scaleFactor
@@ -76,21 +74,16 @@ NSString *const OECoverGridViewGlossDisabledKey = @"OECoverGridViewGlossDisabled
 @end
 
 @implementation OEGridView
-static IKImageWrapper *lightingImage, *noiseImageHighRes, *noiseImage;
+
+static IKImageWrapper *lightingImage;
+
 + (void)initialize
 {
     if([self class] != [OEGridView class])
         return;
 
-
     NSImage *nslightingImage = [NSImage imageNamed:@"background_lighting"];
     lightingImage = [IKImageWrapper imageWithNSImage:nslightingImage];
-
-    OEBackgroundNoisePatternCreate();
-    OEBackgroundHighResolutionNoisePatternCreate();
-
-    noiseImage = [IKImageWrapper imageWithCGImage:OEBackgroundNoiseImageRef];
-    noiseImageHighRes = [IKImageWrapper imageWithCGImage:OEBackgroundHighResolutionNoiseImageRef];
 }
 
 - (instancetype)init
@@ -730,20 +723,10 @@ static IKImageWrapper *lightingImage, *noiseImageHighRes, *noiseImage;
 - (void)drawBackground:(struct CGRect)arg1
 {
     const id <IKRenderer> renderer = [self renderer];
-    const CGFloat scaleFactor = [renderer scaleFactor];
 
     arg1 = [[self enclosingScrollView] documentVisibleRect];
 
     [renderer drawImage:lightingImage inRect:arg1 fromRect:NSZeroRect alpha:1.0];
-
-    IKImageWrapper *image = noiseImageHighRes;
-    if(scaleFactor != 1) image = noiseImageHighRes;
-
-    NSSize imageSize = {image.size.width/scaleFactor, image.size.height/scaleFactor};
-    for(CGFloat y=NSMinY(arg1); y < NSMaxY(arg1); y+=imageSize.height)
-        for(CGFloat x=NSMinX(arg1); x < NSMaxX(arg1); x+=imageSize.width)
-            [renderer drawImage:image inRect:(CGRect){{x,y},imageSize} fromRect:NSZeroRect alpha:1.0]
-            ;
 }
 
 - (void)drawGroupsOverlays

--- a/OpenEmu/OEPrefDebugController.m
+++ b/OpenEmu/OEPrefDebugController.m
@@ -153,7 +153,6 @@ NSString * const OptionsKey = @"options";
                               Button(@"Reset main window size", @selector(resetMainWindow:)),
                               NCheckbox(OEMenuOptionsStyleKey, @"Dark GridView context menu"),
                               Checkbox(OERetrodeSupportEnabledKey, @"Enable Retrode support"),
-                              Checkbox(OECoverGridViewGlossDisabledKey, @"Disable grid view gloss overlay"),
                               Checkbox(OECoverGridViewAutoDownloadEnabledKey, @"Download missing artwork on the fly"),
                               Checkbox(OEDisplayGameTitle, @"Show game titles instead of rom names"),
                               Checkbox(OEImportManualSystems, @"Manually choose system on import"),

--- a/OpenEmu/OEPrefDebugController.xib
+++ b/OpenEmu/OEPrefDebugController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9058" systemVersion="15A282b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9058"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="OEPrefDebugController">
@@ -12,7 +12,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view id="3" userLabel="Debug">
             <rect key="frame" x="0.0" y="0.0" width="320" height="400"/>
             <autoresizingMask key="autoresizingMask"/>
@@ -27,6 +27,7 @@
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="none" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="57" rowSizeStyle="automatic" headerView="O6n-Sf-1nB" viewBased="YES" floatsGroupRows="NO" id="AjZ-JK-lhC">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="383"/>
                                 <autoresizingMask key="autoresizingMask"/>
+                                <animations/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" red="0.1450980392" green="0.1450980392" blue="0.1450980392" alpha="0.0" colorSpace="calibratedRGB"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -51,6 +52,7 @@
                                                     <textField verticalHuggingPriority="750" id="e0G-ml-EgU" customClass="OELabel">
                                                         <rect key="frame" x="18" y="20" width="108" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <animations/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Filter:" id="dkH-jC-1tc" customClass="OELabelCell">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -61,8 +63,9 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </textField>
                                                     <popUpButton focusRingType="none" verticalHuggingPriority="750" id="Ze8-7N-APb" customClass="OEPopUpButton">
-                                                        <rect key="frame" x="129.99999983952597" y="13" width="170" height="26"/>
+                                                        <rect key="frame" x="130" y="13" width="170" height="26"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <animations/>
                                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" focusRingType="none" imageScaling="proportionallyDown" inset="2" id="rZm-BM-nTz" customClass="OEPopUpButtonCell">
                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="menu"/>
@@ -76,6 +79,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </popUpButton>
                                                 </subviews>
+                                                <animations/>
                                             </customView>
                                             <customView identifier="Group" id="mYo-Gd-t0V" userLabel="Group">
                                                 <rect key="frame" x="1" y="60" width="317" height="57"/>
@@ -84,6 +88,7 @@
                                                     <textField verticalHuggingPriority="750" id="ruU-Bh-lmC" customClass="OELabel">
                                                         <rect key="frame" x="18" y="20" width="281" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <animations/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="A Group" id="0Zy-Ms-WXP" customClass="OELabelCell">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -94,6 +99,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </textField>
                                                 </subviews>
+                                                <animations/>
                                             </customView>
                                             <customView identifier="Separator" id="XhB-AC-qND" userLabel="Separator">
                                                 <rect key="frame" x="1" y="119" width="317" height="57"/>
@@ -102,11 +108,13 @@
                                                     <customView id="yqT-sb-0mv" customClass="OEHorizontalLine">
                                                         <rect key="frame" x="0.0" y="26" width="317" height="2"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <animations/>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="string" keyPath="themeKey" value="preferences_line"/>
                                                         </userDefinedRuntimeAttributes>
                                                     </customView>
                                                 </subviews>
+                                                <animations/>
                                             </customView>
                                             <customView identifier="Button" id="m7x-S8-ITI" userLabel="Button">
                                                 <rect key="frame" x="1" y="178" width="317" height="57"/>
@@ -115,6 +123,7 @@
                                                     <button id="ddz-vv-zyE" customClass="OEButton">
                                                         <rect key="frame" x="20" y="17" width="132" height="23"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <animations/>
                                                         <buttonCell key="cell" type="square" title="Reset warnings" bezelStyle="shadowlessSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Luq-cA-h2w" customClass="OEButtonCell">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
@@ -124,6 +133,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </button>
                                                 </subviews>
+                                                <animations/>
                                             </customView>
                                             <customView identifier="Checkbox" id="DuO-rb-1mf" userLabel="Checkbox">
                                                 <rect key="frame" x="1" y="237" width="317" height="54"/>
@@ -132,6 +142,7 @@
                                                     <button id="5C1-Ch-KX4" userLabel="Check Box" customClass="OEButton">
                                                         <rect key="frame" x="18" y="18" width="281" height="18"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <animations/>
                                                         <buttonCell key="cell" type="check" title="a checkbox" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="lDU-Ru-DGH" userLabel="Check Box Cell" customClass="OEButtonCell">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="system"/>
@@ -141,6 +152,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </button>
                                                 </subviews>
+                                                <animations/>
                                             </customView>
                                             <customView identifier="Color" id="cS7-xn-cc2" userLabel="Color">
                                                 <rect key="frame" x="1" y="293" width="317" height="57"/>
@@ -149,6 +161,7 @@
                                                     <textField verticalHuggingPriority="750" id="Wzh-Ve-htz" customClass="OELabel">
                                                         <rect key="frame" x="18" y="20" width="204" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <animations/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="A Label:" id="Ny7-ig-5mo" customClass="OELabelCell">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -161,9 +174,11 @@
                                                     <colorWell id="IoM-L2-luS">
                                                         <rect key="frame" x="228" y="16" width="69" height="24"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <animations/>
                                                         <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     </colorWell>
                                                 </subviews>
+                                                <animations/>
                                             </customView>
                                             <customView identifier="Label" id="1i8-b9-0eC" userLabel="Label">
                                                 <rect key="frame" x="1" y="352" width="317" height="57"/>
@@ -172,6 +187,7 @@
                                                     <textField verticalHuggingPriority="750" id="Bsg-b9-4VO" customClass="OELabel">
                                                         <rect key="frame" x="18" y="20" width="281" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <animations/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="A Label:" id="mOs-p4-603" customClass="OELabelCell">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -182,6 +198,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </textField>
                                                 </subviews>
+                                                <animations/>
                                             </customView>
                                         </prototypeCellViews>
                                     </tableColumn>
@@ -192,22 +209,28 @@
                                 </connections>
                             </tableView>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" red="0.14901960780000001" green="0.14901960780000001" blue="0.14901960780000001" alpha="1" colorSpace="calibratedRGB"/>
                     </clipView>
+                    <animations/>
                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="BFA-B9-CMH" customClass="OEScroller">
                         <rect key="frame" x="-100" y="-100" width="46" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <animations/>
                     </scroller>
-                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="37" horizontal="NO" id="TAN-xy-Ayj" customClass="OEScroller">
+                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="TAN-xy-Ayj" customClass="OEScroller">
                         <rect key="frame" x="-100" y="-100" width="15" height="102"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <animations/>
                     </scroller>
                     <tableHeaderView key="headerView" id="O6n-Sf-1nB">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="17"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <animations/>
                     </tableHeaderView>
                 </scrollView>
             </subviews>
+            <animations/>
         </view>
     </objects>
 </document>

--- a/OpenEmu/OESidebarCell.m
+++ b/OpenEmu/OESidebarCell.m
@@ -267,8 +267,8 @@ const CGFloat BadgeSpacing = 2.0;
         attributes = [[self itemAttributes] textAttributesForState:state];
         
         // Adjust the title frame to fit the system typeface.
-        titleFrame.size.height += 2;
-        titleFrame.origin.y -= 2;
+        titleFrame.size.height += 3;
+        titleFrame.origin.y -= 3;
     }
 
 	NSAttributedString *strVal = [[NSAttributedString alloc] initWithString:[self stringValue] attributes:attributes];

--- a/OpenEmu/OESidebarCell.m
+++ b/OpenEmu/OESidebarCell.m
@@ -261,11 +261,6 @@ const CGFloat BadgeSpacing = 2.0;
 		titleFrame.origin.y += 9;
 		titleFrame.origin.x -= 8;
 		titleFrame.size.width += 8;
-        
-        // NOTE: The bold trait specified in "sidebar_group" in Theme.plist doesn't get applied for some reason, so manually set a bold font for group sidebar items. This is a hack, but since NSCell is deprecated, this code will eventually be replaced by a view-based solution anyway.
-        NSMutableDictionary *mutableAttributes = [attributes mutableCopy];
-        mutableAttributes[NSFontAttributeName] = [NSFont boldSystemFontOfSize:11];
-        attributes = mutableAttributes;
     }
     else
     {

--- a/OpenEmu/OEThemeTextAttributes.m
+++ b/OpenEmu/OEThemeTextAttributes.m
@@ -65,19 +65,24 @@ static id _OEObjectFromDictionary(NSDictionary *dictionary, NSString *attributeN
 // Parses a comma separated NSString of theme font traits
 NSFontTraitMask _OENSFontTraitMaskFromString(NSString *string)
 {
-    __block NSFontTraitMask mask = 0;
-
-    [[string componentsSeparatedByString:@","] enumerateObjectsUsingBlock:
-     ^ (NSString *obj, NSUInteger idx, BOOL *stop)
-     {
-         NSString *trait = [obj stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-
-         if([trait caseInsensitiveCompare:OEThemeFontTraitBoldName]        == NSOrderedSame) mask |= NSBoldFontMask;
-         else if([trait caseInsensitiveCompare:OEThemeFontTraitUnboldName] == NSOrderedSame) mask |= NSUnboldFontMask;
-         else if([trait caseInsensitiveCompare:OEThemeFontTraitItalicName] == NSOrderedSame) mask |= NSItalicFontMask;
-         else if([trait caseInsensitiveCompare:OEThemeFontTraitUnitalic]   == NSOrderedSame) mask |= NSUnitalicFontMask;
-     }];
-
+    NSFontTraitMask mask = 0;
+    NSCharacterSet *whitespace = [NSCharacterSet whitespaceCharacterSet];
+    
+    for(NSString *token in [string componentsSeparatedByString:@","]) {
+        
+        NSString *trimmedToken = [token stringByTrimmingCharactersInSet:whitespace];
+        
+        if([trimmedToken caseInsensitiveCompare:OEThemeFontTraitBoldName] == NSOrderedSame) {
+            mask |= NSBoldFontMask;
+        } else if([trimmedToken caseInsensitiveCompare:OEThemeFontTraitUnboldName] == NSOrderedSame) {
+            mask |= NSUnboldFontMask;
+        } else if([trimmedToken caseInsensitiveCompare:OEThemeFontTraitItalicName] == NSOrderedSame) {
+            mask |= NSItalicFontMask;
+        } else if([trimmedToken caseInsensitiveCompare:OEThemeFontTraitUnitalic] == NSOrderedSame) {
+            mask |= NSUnitalicFontMask;
+        }
+    }
+    
     return mask;
 }
 

--- a/OpenEmu/en.lproj/Library.xib
+++ b/OpenEmu/en.lproj/Library.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9058" systemVersion="15A282b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9058"/>
         <capability name="box content view" minToolsVersion="7.0"/>
     </dependencies>
     <objects>
@@ -74,7 +74,7 @@
                                     </subviews>
                                     <animations/>
                                 </customView>
-                                <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="549">
+                                <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="21" horizontalPageScroll="10" verticalLineScroll="21" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="549">
                                     <rect key="frame" x="0.0" y="36" width="186" height="564"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <clipView key="contentView" id="KU4-pj-msp">
@@ -85,7 +85,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="186" height="19"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <animations/>
-                                                <size key="intercellSpacing" width="3" height="2"/>
+                                                <size key="intercellSpacing" width="3" height="4"/>
                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                 <tableColumns>


### PR DESCRIPTION
To cope with the inability to specify the system typeface without resorting to private names, the system typeface can be specified in Theme.plist via special tokens:

- `$SYSTEM_FONT_FAMILY` - System font
- `$MONOSPACED_DIGIT_SYSTEM_FONT_FAMILY` - Monospaced digit system font
- `$LABEL_FONT_FAMILY` - Label font

Block-based enumeration of arrays in OEThemeObject was replaced with more efficient fast enumeration versions. Block-based enumeration over dictionaries was unchanged since that is more efficient due to not having to retrieve the value each time.

Finally, the sidebar and grid view have been tweaked to better fit the lightweight typeface. Intercell spacing was increased in the sidebar, shadows were lessened or removed in the grid view, glossy overlays were removed from grid cells, and the background noise pattern was removed from the grid view.

![screen shot 2015-10-18 at 5 23 14 am](https://cloud.githubusercontent.com/assets/238567/10563847/84f4dfa6-7558-11e5-8bf4-c08cab3357d7.png)