### PR TITLE
Fix bugs in BIOS preferences

### DIFF
--- a/OpenEmu/OEPrefBiosController.m
+++ b/OpenEmu/OEPrefBiosController.m
@@ -182,15 +182,17 @@ static void *const _OEPrefBiosCoreListContext = (void *)&_OEPrefBiosCoreListCont
         // Change cursors
         [attributes     setObject:[NSCursor arrowCursor]        forKey:NSCursorAttributeName];
         [linkAttributes setObject:[NSCursor pointingHandCursor] forKey:NSCursorAttributeName];
-
-        NSString *infoText = [NSString stringWithFormat:NSLocalizedString(@"In order to emulate some systems, BIOS files are needed due to increasing complexity of the hardware and software of modern gaming consoles. Please read our %@ for more information.", @"BIOS files preferences introduction text"), OEBiosUserGuideURLString];
+        [linkAttributes setObject:[NSURL URLWithString:OEBiosUserGuideURLString] forKey:NSLinkAttributeName];
+        
+        NSString *wildcard = @"\uFFFC";
+        NSString *infoText = [NSString stringWithFormat:NSLocalizedString(@"In order to emulate some systems, BIOS files are needed due to increasing complexity of the hardware and software of modern gaming consoles. Please read our %@ for more information.", @"BIOS files preferences introduction text"), wildcard];
         NSString *linkText = NSLocalizedString(@"User guide on BIOS files", @"Bios files introduction text, active region");
         NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:infoText attributes:attributes];
 
-        NSRange linkRange = [infoText rangeOfString:OEBiosUserGuideURLString];
-        [attributedString setAttributes:@{NSLinkAttributeName:[NSURL URLWithString:OEBiosUserGuideURLString]} range:linkRange];
+        NSRange linkRange = [infoText rangeOfString:wildcard];
+        [attributedString setAttributes:linkAttributes range:linkRange];
         [attributedString replaceCharactersInRange:linkRange withString:linkText];
-
+        
         [groupCell setObjectValue:attributedString];
 
         NSTextView *textView = [[[groupCell subviews] lastObject] documentView];

--- a/OpenEmu/OEPrefBiosController.m
+++ b/OpenEmu/OEPrefBiosController.m
@@ -63,7 +63,7 @@ static void *const _OEPrefBiosCoreListContext = (void *)&_OEPrefBiosCoreListCont
     return self;
 }
 
-- (void)awakeFromNib
+- (void)viewDidLoad
 {
     NSTableView *view = [self tableView];
 


### PR DESCRIPTION
This PR fixes
- the font of the link to the guide in the BIOS preferences (it was Helvetica, now it's San Francisco),
- a crashing bug which could occur when clicking on that link.

The first bug was easy to fix. Since the attributes you can set with ``-setLinkTextAttributes:`` are what Apple calls "temporary attributes" (this means they are applied during the drawing stage, after the placement of every character has been decided), any font attribute you set that way will be ignored. The fix was to apply the full set of attributes to the link in the attributed string. I also took the opportunity to make the logic for inserting the link a little faster and more robust (but that's just OCD at work).

On the other hand, the crashing bug was really confusing: it crashed because the NSURL of the link was deallocated before it was passed on to the delegate, which should be impossible because that NSURL should be retained by the NSTextView that contains the link!
I reproduced the bug in Instruments, and the stack trace for the calls which deallocated the clicked NSURL gave away the clue. Basically, the problem is that the view was initialized in ``-awakeFromNib``. 

The fix was to move all the code in ``-awakeFromNib`` to ``-viewDidLoad``. ``-viewDidLoad`` is a method of NSViewController added in Yosemite, which is called right after the view property of the controller is set, and is intended for initializing the view, which is what we are doing here. After this change, I couldn't reproduce this bug anymore.

---

What follows is my theory on why exactly initializing that particular view in ``-awakeFromNib`` caused the crashes.

When instantiating a view, OEPrefBiosController's implementation of ``-tableView:viewForTableColumn:row`` calls ``-makeViewWithIdentifier:owner:`` on the table, which might call ``-awakeFromNib`` on the owner of the nib: the same instance of OEPrefBiosController which owns the table ([documentation](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSTableView_Class/#//apple_ref/occ/instm/NSTableView/makeViewWithIdentifier:owner:)).  But, OEPrefBiosController's ``-awakeFromNib`` calls ``-reloadData`` on the table! NSTableView does not take in account that somebody might call reloadData while it's adding views, and then proceeds in removing all the views it already added, putting them in its pool of reusable views, and then scheduling a new round of updates on the main thread's run loop.

In the end, every time the BIOS preferences' NSTableView tries to load some views, two things could happen:
- it gets them from the pool, and everything works as expected because ``-awakeFromNib`` is not called **
- the pool is empty, and ``-awakeFromNib`` removes all views already added to the NSTableView, putting them in the pool

When the pool contains more views than the table needs, everything settles down.

** Note: The documentation I linked to says that "Note that awakeFromNib is called each time this method is called,[...]", but it's incorrect. The header file for NSTableView (a more reliable source because it was presumably written by the same engineers who wrote the code) says "Note that 'owner' will get an 'awakeFromNib:' call *each time the object is instantiated*." which is different because, if the view was retrieved from the pool, the view was already instantiated in the past.

NSTableView also runs a prefetch task in background, which obviously calls ``-tableView:viewForTableColumn:row`` on the BIOS preferences view controller. This task triggers on a timer, and runs on the main thread. If the user is clicking on the link, the run loop receives the event and it might decide it's also the time to prefetch the table rows, if the timer has expired.

The prefetch method might be called before the mouse event is processed. If the table's reusable view pool is empty, it will call ``-awakeFromNib`` on the view controller, which will then remove all the table view's views, included the one which was clicked by the user.

When this view is put in the pool of reusable views, its objectValue outlet is set to nil; this means that the text view's contents become an empty string and our NSURL is deallocated. The text view's NSTextStorage fires a notification that it has changed, and the text view responds by invalidating its layout (which won't be recomputed soon, because the view is offscreen). But NSTextView stores the hitboxes for links in a separate structure; and every hitbox keeps an unsafe unretained reference to the NSURL that was deallocated. When the NSTextView finally receives the event, it will register the hit on the link anyway, and it will give the delegate an invalid pointer.

---

Another strange phenomenon I observed with that table view: scrolling the view, you could get it to a place (near the bottom) where for some reason it would continuously load new views from the xib and, as a result, the view would start flashing and leaking memory! (yes I'm totally lucid, I have a video of it if you can't reproduce it yourself.) The fix for the crashing bug also fixes this cosmetic bug.

