### PR TITLE
Fix search field caret

### DIFF
--- a/Interface Graphics/Theme.plist
+++ b/Interface Graphics/Theme.plist
@@ -1081,6 +1081,8 @@
 			</dict>
 			<key>Weight</key>
 			<real>0.2</real>
+			<key>Baseline Offset</key>
+			<integer>3</integer>
 		</dict>
 		<key>search_field_selection</key>
 		<dict>
@@ -1129,6 +1131,8 @@
 			</dict>
 			<key>Weight</key>
 			<real>0.2</real>
+			<key>Baseline Offset</key>
+			<integer>3</integer>
 		</dict>
 		<key>wood_popup_button</key>
 		<dict>

--- a/OpenEmu/OEThemeTextAttributes.m
+++ b/OpenEmu/OEThemeTextAttributes.m
@@ -44,6 +44,7 @@ static NSString * const OEThemeFontWeightAttributeName          = @"Weight";
 static NSString * const OEThemeFontTraitsAttributeName          = @"Traits";
 static NSString * const OEThemeFontAlignmentAttributeName       = @"Alignment";
 static NSString * const OEThemeFontLineBreakAttributeName       = @"Line Break";
+static NSString * const OEThemeFontBaselineOffsetAttributeName  = @"Baseline Offset";
 
 #pragma mark - Theme font shadow
 
@@ -138,6 +139,7 @@ id _OEObjectFromDictionary(NSDictionary *dictionary, NSString *attributeName, Cl
     NSString   *familyAttribute = ([definition valueForKey:OEThemeFontFamilyAttributeName]   ?: [definition objectForKey:OEThemeObjectValueAttributeName]);
     CGFloat     size            = [([definition objectForKey:OEThemeFontSizeAttributeName]   ?: [NSNumber numberWithFloat:12.0]) floatValue];
     CGFloat  weight          = [([definition objectForKey:OEThemeFontWeightAttributeName] ?: [NSNumber numberWithFloat:5]) floatValue];
+    NSNumber *baselineOffset = [definition objectForKey:OEThemeFontBaselineOffsetAttributeName];
 
     NSFontTraitMask  mask = [_OEObjectFromDictionary(definition, OEThemeFontTraitsAttributeName, [NSNumber class],
                                                      ^ id (id mask)
@@ -214,6 +216,7 @@ id _OEObjectFromDictionary(NSDictionary *dictionary, NSString *attributeName, Cl
     if(foregroundColor) [attributes setValue:foregroundColor forKey:NSForegroundColorAttributeName];
     if(backgroundColor) [attributes setValue:backgroundColor forKey:NSBackgroundColorAttributeName];
     if(style)           [attributes setValue:style           forKey:NSParagraphStyleAttributeName];
+    if(baselineOffset)  [attributes setObject:baselineOffset forKey:NSBaselineOffsetAttributeName];
 
     return [attributes copy];
 }


### PR DESCRIPTION
This PR fixes the white line at the bottom of the caret.

The root issue is that, for some reason, the caret changed size when typing the first letter, spilling out of the field's border. This didn't seem to change even when making the text view initially larger.

To fix the problem, I moved the text rect down to place the caret in the right position, and then I changed the text's attributes to center it vertically. The caret's new position is always the same now, and it doesn't spill out of the view.

The code I deleted tried to fix the caret's size and placement by changing how the caret was drawn to make it always the right size. But, when the field editor is blank, the "real" caret rect was placed higher than the modified caret, and NSTextView would only invalidate the "real" caret when it had to erase it, thus the bottom part of the new caret (the white line) never got erased.

I also deleted the code that set up the field editor's typing attributes because it had no effect. NSTextFieldCell already sets them using the ``_textAttributes`` property when it copies its current value into the field editor.