### PR TITLE
Add issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+### Expected behavior
+
+Replace this with your expecations.
+
+### Actual behavior
+
+Replace this with what actually happened.
+
+### Steps to reproduce this behavior
+
+1. Start OpenEmu
+2. ...
+
+### Crash log
+
+```
+Paste your crash log here
+```


### PR DESCRIPTION
Issue templates are automatically used when people open new issues. The
template file can optionally be hidden by putting it in a `.github` directory.

Open for suggestions as to the actual contents of the template, but I figure this can remedy the recurring lack of crash logs in issues, and other things.