### PR TITLE
Fixed suppressed alert value when using callbacks

### DIFF
--- a/OpenEmu/OEHUDAlert.m
+++ b/OpenEmu/OEHUDAlert.m
@@ -153,10 +153,10 @@ static const CGFloat _OEHUDAlertMinimumHeadlineLength   = 291.0;
 {
     if([self suppressionUDKey] && [[NSUserDefaults standardUserDefaults] valueForKey:[self suppressionUDKey]])
     {
-        _result = [[NSUserDefaults standardUserDefaults] integerForKey:[self suppressionUDKey]];
-        NSInteger suppressionValue = (_result == 1 ? NSAlertFirstButtonReturn : NSAlertSecondButtonReturn);
+        NSInteger suppressionValue = [[NSUserDefaults standardUserDefaults] integerForKey:[self suppressionUDKey]];
+        _result = (suppressionValue == 1 ? NSAlertFirstButtonReturn : NSAlertSecondButtonReturn);
         [self OE_performCallback];
-        return suppressionValue;
+        return _result;
     }
 
     [self OE_autosizeWindow];


### PR DESCRIPTION
I noticed the "change core will break save states" warning would not remember the choice correctly when suppressed (it would remember a no when I chose a yes).

This change makes OEHUDAlert pass the correct button value to the callback by setting `_result` (which is read in `OE_performCallback`) to the recovered button value instead of the flag from `NSUserDefaults`. Now the value returned from runModal and the one passed to the callback are the same.