### PR TITLE
Update Russian Localization OELibraryController.strings

### DIFF
--- a/OpenEmu/ru.lproj/OELibraryController.strings
+++ b/OpenEmu/ru.lproj/OELibraryController.strings
@@ -6,10 +6,10 @@
 "DQz-qS-W9j.ibShadowedLabels[0]" = "Библиотека";
 
 /* Class = "NSSegmentedCell"; y2e-ND-lKU.ibShadowedLabels[1] = "Save States"; ObjectID = "y2e-ND-lKU"; */
-"DQz-qS-W9j.ibShadowedLabels[1]" = "Сохранить состояние";
+"DQz-qS-W9j.ibShadowedLabels[1]" = "Сохранения";
 
 /* Class = "NSSegmentedCell"; y2e-ND-lKU.ibShadowedLabels[2] = "Screenshots"; ObjectID = "y2e-ND-lKU"; */
-"DQz-qS-W9j.ibShadowedLabels[2]" = "Снимки экрана";
+"DQz-qS-W9j.ibShadowedLabels[2]" = "Скриншоты";
 
 /* Class = "NSSegmentedCell"; y2e-ND-lKU.ibShadowedLabels[3] = "Homebrew"; ObjectID = "y2e-ND-lKU"; */
 "DQz-qS-W9j.ibShadowedLabels[3]" = "Homebrew";


### PR DESCRIPTION
"Save States" was literal translation and transladed as a verb. "Screenshots" is ok as "Снимки экрана" but "Скриншоты" is more common and fits well in top bar (top bar buttons is a mess with current translation).