### PR TITLE
Fix using the Esc key in the controls preferences with the Touch Bar

### DIFF
--- a/OpenEmu/OEPrefControlsController.m
+++ b/OpenEmu/OEPrefControlsController.m
@@ -610,12 +610,6 @@ static CFHashCode _OEHIDEventHashSetCallback(OEHIDEvent *value)
     // Ignore any off state events
     if([anEvent hasOffState] || [self selectedKey] == nil) return;
 
-    if([anEvent isEscapeKeyEvent])
-    {
-        [[self currentPlayerBindings] removeEventForKeyWithName:[self selectedKey]];
-        return;
-    }
-
     [self OE_setCurrentBindingsForEvent:anEvent];
 
     id assignedKey = [[self currentPlayerBindings] assignEvent:anEvent toKeyWithName:[self selectedKey]];
@@ -630,6 +624,11 @@ static CFHashCode _OEHIDEventHashSetCallback(OEHIDEvent *value)
 
 - (void)keyDown:(NSEvent *)theEvent
 {
+    if ([self selectedKey] == nil)
+        return;
+    
+    if ([theEvent keyCode] == kVK_Escape)
+        [[self currentPlayerBindings] removeEventForKeyWithName:[self selectedKey]];
 }
 
 - (void)keyUp:(NSEvent *)theEvent
@@ -669,9 +668,13 @@ static CFHashCode _OEHIDEventHashSetCallback(OEHIDEvent *value)
         return NO;
     }
 
+    // Esc-key events are handled through NSEvent
+    if ([anEvent isEscapeKeyEvent])
+        return NO;
+
     // Ignore keyboard events if the user hasn’t explicitly chosen to configure
     // keyboard bindings. See https://github.com/OpenEmu/OpenEmu/issues/403
-    if([anEvent type] == OEHIDEventTypeKeyboard && ![self isKeyboardEventSelected] && ![anEvent isEscapeKeyEvent])
+    if([anEvent type] == OEHIDEventTypeKeyboard && ![self isKeyboardEventSelected])
         return NO;
 
     // No event currently read, if it's not off state, store it and read it


### PR DESCRIPTION
The controls preference panel listens for an Esc-key HID event to remove control bindings. Since OpenEmu doesn't listen for HID events from the Touch Bar because of #2851, users with a Touch Bar will not be able to remove key bindings.

This PR fixes the issue by receiving Esc key presses through NSEvent instead than through HID.