### PR TITLE
Add sixtyforce core to Openemu

### DIFF
--- a/OpenEmu/OEImportOperation.m
+++ b/OpenEmu/OEImportOperation.m
@@ -486,6 +486,9 @@ NSString * const OEImportManualSystems = @"OEImportManualSystems";
                 if(i != 0){
                     op = [OEImportOperation operationWithURL:self.URL inImporter:self.importer];
                     op.URL = self.URL;
+                    op.completionHandler = self.completionHandler;
+                    op.collectionID = self.collectionID;
+
                     [self.derivedImports addObject:op];
                 }
 

--- a/OpenEmu/OEImportOperation.m
+++ b/OpenEmu/OEImportOperation.m
@@ -489,6 +489,7 @@ NSString * const OEImportManualSystems = @"OEImportManualSystems";
                     op.URL = self.URL;
                     op.completionHandler = self.completionHandler;
                     op.collectionID = self.collectionID;
+                    op.queuePriority = NSOperationQueuePriorityHigh;
 
                     [self.derivedImports addObject:op];
                 }

--- a/OpenEmu/OEImportOperation.m
+++ b/OpenEmu/OEImportOperation.m
@@ -437,7 +437,7 @@ NSString * const OEImportManualSystems = @"OEImportManualSystems";
             if([extension isEqualToString:@"bin"]) return;
 
             for(int i = 1; i < archive.numberOfEntries; i++)
-                if(![[archive nameOfEntry:0].pathExtension isEqualToString:extension])
+                if(![[archive nameOfEntry:i].pathExtension.lowercaseString isEqualToString:extension])
                     return;
         }
 

--- a/OpenEmu/OEImportOperation.m
+++ b/OpenEmu/OEImportOperation.m
@@ -432,8 +432,9 @@ NSString * const OEImportManualSystems = @"OEImportManualSystems";
         
         // disable multi-rom archives
         if(archive.numberOfEntries > 1) {
-            NSString *extension = [archive nameOfEntry:0].pathExtension;
+            NSString *extension = [archive nameOfEntry:0].pathExtension.lowercaseString;
             if(!extension.length) return;
+            if([extension isEqualToString:@"bin"]) return;
 
             for(int i = 1; i < archive.numberOfEntries; i++)
                 if(![[archive nameOfEntry:0].pathExtension isEqualToString:extension])

--- a/OpenEmu/OEImportOperation.m
+++ b/OpenEmu/OEImportOperation.m
@@ -58,7 +58,7 @@ NSString * const OEImportManualSystems = @"OEImportManualSystems";
 @property (copy) NSString *crcHash;
 
 @property (nullable) OEDBRom *rom;
-
+@property (nullable) NSMutableArray *derivedImports;
 @end
 
 @implementation OEImportOperation
@@ -217,6 +217,7 @@ NSString * const OEImportManualSystems = @"OEImportManualSystems";
         _shouldExit = NO;
         _archiveFileIndex = NSNotFound;
         _exploreArchives  = YES;
+        _derivedImports = [NSMutableArray array];
     }
     return self;
 }
@@ -229,6 +230,7 @@ NSString * const OEImportManualSystems = @"OEImportManualSystems";
         self.URL = [decoder decodeObjectForKey:@"URL"];
         self.sourceURL = [decoder decodeObjectForKey:@"sourceURL"];
         self.exitStatus = OEImportExitNone;
+        self.derivedImports = [NSMutableArray array];
     }
     return self;
 }
@@ -262,6 +264,7 @@ NSString * const OEImportManualSystems = @"OEImportManualSystems";
     copy.archiveFileIndex = self.archiveFileIndex;
     copy.md5Hash = self.md5Hash;
     copy.crcHash = self.crcHash;
+    copy.derivedImports = self.derivedImports;
 
     return copy;
 }
@@ -483,6 +486,7 @@ NSString * const OEImportManualSystems = @"OEImportManualSystems";
                 if(i != 0){
                     op = [OEImportOperation operationWithURL:self.URL inImporter:self.importer];
                     op.URL = self.URL;
+                    [self.derivedImports addObject:op];
                 }
 
                 op.extractedFileURL = tmpURL;


### PR DESCRIPTION
The N64 core Mupen64Plus is nice and all but I feel that the emulator sixtyforce is better for it doesn't have the same graphics issues that Mupen64Plus has so I am requesting that you guys add the sixtyforce core to the emulator for your next update.