### PR TITLE
Add 'Undo Load' functionality

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -861,7 +861,7 @@ extension AppDelegate: NSMenuDelegate {
             newSaveItem.representedObject = "0"
         }
         
-        undoLoadItem = NSMenuItem(title: NSLocalizedString("Undo Load", comment: "Undo Load Menu Item"), action: #selector(OEGameDocument.quickLoad(_:)), keyEquivalent: "l")
+        undoLoadItem = NSMenuItem(title: NSLocalizedString("Undo Last Load", comment: "Undo Last Load Menu Item"), action: #selector(OEGameDocument.quickLoad(_:)), keyEquivalent: "l")
         undoLoadItem.representedObject = "0"
 
         newLoadItem.tag = loadItemTag

--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -819,6 +819,7 @@ extension AppDelegate: NSMenuDelegate {
         
         let newLoadItem: NSMenuItem
         let newSaveItem: NSMenuItem
+        let undoLoadItem: NSMenuItem
         
         if useSlots {
             
@@ -860,6 +861,9 @@ extension AppDelegate: NSMenuDelegate {
             newSaveItem.representedObject = "0"
         }
         
+        undoLoadItem = NSMenuItem(title: NSLocalizedString("Undo Load", comment: "Undo Load Menu Item"), action: #selector(OEGameDocument.quickLoad(_:)), keyEquivalent: "l")
+        undoLoadItem.representedObject = "0"
+
         newLoadItem.tag = loadItemTag
         newSaveItem.tag = saveItemTag
         

--- a/OpenEmu/OEDBSaveState.h
+++ b/OpenEmu/OEDBSaveState.h
@@ -43,6 +43,7 @@ extern NSString *const OESaveStateInfoCoreVersionKey;
 extern NSString *const OESaveStateSpecialNamePrefix;
 extern NSString *const OESaveStateAutosaveName;
 extern NSString *const OESaveStateQuicksaveName;
+extern NSString *const OESaveStateUndoLoadName;
 
 extern NSString *const OESaveStateUseQuickSaveSlotsKey;
 

--- a/OpenEmu/OEDBSaveState.m
+++ b/OpenEmu/OEDBSaveState.m
@@ -58,6 +58,7 @@ NSString *const OESaveStateInfoTimestampKey         = @"Timestamp";
 NSString *const OESaveStateSpecialNamePrefix    = @"OESpecialState_";
 NSString *const OESaveStateAutosaveName         = @"OESpecialState_auto";
 NSString *const OESaveStateQuicksaveName        = @"OESpecialState_quick";
+NSString *const OESaveStateUndoLoadName         = @"OESpecialState_undo";
 
 @implementation OEDBSaveState
 

--- a/OpenEmu/OEDBSaveState.m
+++ b/OpenEmu/OEDBSaveState.m
@@ -587,7 +587,7 @@ NSString *const OESaveStateUndoLoadName         = @"OESpecialState_undo";
     }
     else if([name isEqualToString:OESaveStateUndoLoadName])
     {
-        return NSLocalizedString(@"State Before Last Load", @"Undo Load state display name");
+        return NSLocalizedString(@"State Before Last Load", @"Undo Last Load state display name");
     }
     else if([name isEqualToString:OESaveStateQuicksaveName])
     {

--- a/OpenEmu/OEDBSaveState.m
+++ b/OpenEmu/OEDBSaveState.m
@@ -585,6 +585,10 @@ NSString *const OESaveStateUndoLoadName         = @"OESpecialState_undo";
     {
         return NSLocalizedString(@"Auto Save State", @"Autosave state display name");
     }
+    else if([name isEqualToString:OESaveStateUndoLoadName])
+    {
+        return NSLocalizedString(@"State Before Last Load", @"Undo Load state display name");
+    }
     else if([name isEqualToString:OESaveStateQuicksaveName])
     {
         return NSLocalizedString(@"Quick Save State", @"Quicksave state display name");

--- a/OpenEmu/OEGameControlsBar.m
+++ b/OpenEmu/OEGameControlsBar.m
@@ -533,11 +533,6 @@ NSString *const OEGameControlsBarShowsAudioOutput       = @"HUDBarShowAudioOutpu
     [menu setDelegate:self];
     [menu addItem:newSaveItem];
 
-    NSMenuItem *undoLoadItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Undo Load", @"") action:@selector(undoLoadState:) keyEquivalent:@""];
-    [undoLoadItem setEnabled:[[self gameViewController] supportsSaveStates]];
-    [menu setDelegate:self];
-    [menu addItem:undoLoadItem];
-
     OEDBRom *rom = [[[self gameViewController] document] rom];
     [rom removeMissingStates];
 
@@ -595,6 +590,12 @@ NSString *const OEGameControlsBarShowsAudioOutput       = @"HUDBarShowAudioOutpu
                 [loadItem setSubmenu:loadSubmenu];
                 [menu addItem:loadItem];
             }
+
+            NSString *undoLoadTitle = NSLocalizedString(@"Undo Last Load", @"Undo Last Load menu item title");
+            item = [[NSMenuItem alloc] initWithTitle:undoLoadTitle action:@selector(undoLoadState:) keyEquivalent:@""];
+            [item setEnabled:[[self gameViewController] supportsSaveStates]];
+            [item setIndentationLevel:1];
+            [menu addItem:item];
 
             // Add 'normal' save states
             for(OEDBSaveState *saveState in saveStates)

--- a/OpenEmu/OEGameControlsBar.m
+++ b/OpenEmu/OEGameControlsBar.m
@@ -533,6 +533,11 @@ NSString *const OEGameControlsBarShowsAudioOutput       = @"HUDBarShowAudioOutpu
     [menu setDelegate:self];
     [menu addItem:newSaveItem];
 
+    NSMenuItem *undoLoadItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"Undo Load", @"") action:@selector(undoLoadState:) keyEquivalent:@""];
+    [undoLoadItem setEnabled:[[self gameViewController] supportsSaveStates]];
+    [menu setDelegate:self];
+    [menu addItem:undoLoadItem];
+
     OEDBRom *rom = [[[self gameViewController] document] rom];
     [rom removeMissingStates];
 

--- a/OpenEmu/OEGameCoreHelper.h
+++ b/OpenEmu/OEGameCoreHelper.h
@@ -60,6 +60,7 @@
 
 - (void)saveState;
 - (void)loadState;
+- (void)undoLoadState;
 - (void)quickSave;
 - (void)quickLoad;
 - (void)toggleFullScreen;

--- a/OpenEmu/OEGameDocument.m
+++ b/OpenEmu/OEGameDocument.m
@@ -1334,7 +1334,20 @@ typedef enum : NSUInteger
         return;
     }
 
+    [self OE_saveStateWithName:OESaveStateUndoLoadName completionHandler:nil];
+
     [self OE_loadState:state];
+}
+
+- (void)undoLoadState
+{
+    [self undoLoadState:nil];
+}
+
+- (void)undoLoadState:(id)sender;
+{
+    OEDBSaveState *state = [[self rom] saveStateWithName:OESaveStateUndoLoadName];
+    if(state!= nil) [self OE_loadState:state];
 }
 
 - (void)quickLoad
@@ -1349,6 +1362,8 @@ typedef enum : NSUInteger
         slot = [[sender representedObject] integerValue];
     else if([sender respondsToSelector:@selector(tag)])
         slot = [sender tag];
+
+    [self OE_saveStateWithName:OESaveStateUndoLoadName completionHandler:nil];
 
     OEDBSaveState *quicksaveState = [[self rom] quickSaveStateInSlot:slot];
     if(quicksaveState!= nil) [self loadState:quicksaveState];

--- a/OpenEmu/en.lproj/Localizable.strings
+++ b/OpenEmu/en.lproj/Localizable.strings
@@ -496,7 +496,7 @@
 
 "Trash downloaded Files" = "Trash downloaded Files";
 
-"Undo Load" = "Undo Load"
+"Undo Last Load" = "Undo Last Load"
 
 "Unmute Audio" = "Unmute Audio";
 

--- a/OpenEmu/en.lproj/Localizable.strings
+++ b/OpenEmu/en.lproj/Localizable.strings
@@ -442,6 +442,8 @@
 
 "Start Scanning" = "Start Scanning";
 
+"State Before Last Load" = "State Before Last Load";
+
 "Stop Emulation" = "Stop Emulation";
 
 "Stop" = "Stop";
@@ -493,6 +495,8 @@
 "Toggle Fullscreen" = "Toggle Fullscreen";
 
 "Trash downloaded Files" = "Trash downloaded Files";
+
+"Undo Load" = "Undo Load"
 
 "Unmute Audio" = "Unmute Audio";
 


### PR DESCRIPTION
Whenever we Load or QuickLoad (before we load) we write to the
'OESpecialState_undo' save buffer. When the user clicks 'Undo Load',
we load from that buffer to get back where we are.

This means that when the user accidentally forgets to save for an
hour, and then loads their last save state, they can click 'Undo
Load' and get back to where they were (which may not be amazing,
but may be better than losing an hour's progress)

Note that there is only one buffer, so if you go hunting around for
a good save state and can't find one, you're still screwed.

The menu item looks like this:
<img width="491" alt="screen shot 2017-02-27 at 21 27 14" src="https://cloud.githubusercontent.com/assets/25884254/23381072/0d759856-fd35-11e6-8d59-598d53aa6183.png">


Things that I would like to improve but haven't quite worked out yet:
1. I kind-of feel like it should probably be greyed out if you've not got an "undo" buffer lying around, but I'm not sure it's worth the extra complexity, since the menu item will become active from the first time you load a saved state and then stay active for that game until the end of time.

2. I currently leave a OESpecialState_undo save lying around, which you can see via the "Save States" tab. I managed to make it show up with a useful name, ~~but now I've noticed that it's leaving multiple copies lying around, and sometimes they're broken, which causes the "Undo Load" menu item to just do nothing. Hopefully I can crib from the "Auto Save State" code to work out how to fix that.~~ For some reason I can't reproduce this problem today. When it was showing up, it looked like this:
<img width="645" alt="screen shot 2017-02-26 at 18 23 45" src="https://cloud.githubusercontent.com/assets/25884254/23342396/5f530454-fc51-11e6-804e-8c2e3e35ce7c.png">


3. I don't currently have any translations for the new "Undo Last Load" and "State Since Last Load" strings that I introduce other than in `OpenEmu/en.lproj/Localizable.strings`. Who do I need to talk to about getting it translated?

4. Should I be attempting to hide this functionality behind a `UserDefaults.standard.bool`? If so, where should the configuration for it live, and should it default to on or off, or be different per platform?

5. I have a warning about `OpenEmu/OEGameControlsBar.m:595:76: Undeclared selector 'undoLoadState:'` but the code does seem to work just fine. I suspect that this is just me not quite understanding how Objective C fits together (I'm more comfortable with C so I mostly just grepped for loadState and copied that. Clearly I'm missing something.)