### PR TITLE
Fix issue loading MAME ROM save states during game startup

### DIFF
--- a/OpenEmu/OEGameDocument.m
+++ b/OpenEmu/OEGameDocument.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2009, OpenEmu Team
+ Copyright (c) 2009, 2017 OpenEmu Team
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
@@ -696,12 +696,6 @@ typedef enum : NSUInteger
             [[self rom] markAsPlayedNow];
             _lastPlayStartDate = [NSDate date];
 
-            if(_saveStateForGameStart)
-            {
-                [self OE_loadState:_saveStateForGameStart];
-                _saveStateForGameStart = nil;
-            }
-
             // set initial volume
             [self setVolume:[self volume] asDefault:NO];
 
@@ -732,6 +726,12 @@ typedef enum : NSUInteger
          _emulationStatus = OEEmulationStatusPlaying;
      }];
     
+	if(_saveStateForGameStart)
+	{
+		[self OE_loadState:_saveStateForGameStart];
+		_saveStateForGameStart = nil;
+	}
+	
     [[self gameViewController] reflectEmulationPaused:NO];
 }
 


### PR DESCRIPTION
This commit fixes issue #3149. See the issue for detailed steps on how to reproduce the bug. While determining the steps to reproduce the issue, I noticed that manually loading the save states worked fine. This fix moves the call to load a game state during during game startup to a slightly later time. The load now occurs just after the emulation job is dispatched. With this fix ROMs loaded without issue even when a save state is loaded during game startup