### PR TITLE
Fix blurry screenshots bug (#3036)

### DIFF
--- a/OpenEmu/OEGameView.m
+++ b/OpenEmu/OEGameView.m
@@ -1249,7 +1249,13 @@ static CVReturn OEGameViewDisplayLinkCallback(CVDisplayLinkRef displayLink,const
 
     // Flip the image
     [screenshotImage lockFocusFlipped:YES];
-    [imageRep drawInRect:(NSRect){.size = imageSize}];
+    NSRect rect = (NSRect){.size = imageSize};
+    [imageRep drawInRect:rect
+                fromRect:rect
+               operation:NSCompositingOperationCopy
+                fraction:1.0
+          respectFlipped:NO
+                   hints:@{NSImageHintInterpolation:[NSNumber numberWithInt:NSImageInterpolationNone]}];
     [screenshotImage unlockFocus];
 
     return screenshotImage;


### PR DESCRIPTION
The ``drawInRect`` call is used to vertically flip the image buffer (because for some reason imageRep is upside-down), but this operation introduces blurry artifacts as an unintended side-effect. I've modified the call to disable interpolation, resulting in crisp screenshots.