### PR TITLE
Fix #1773: Time out controller mapping read events

### DIFF
--- a/OpenEmu/OEPrefControlsController.m
+++ b/OpenEmu/OEPrefControlsController.m
@@ -54,6 +54,7 @@ static NSString *const _OEKeyboardMenuItemRepresentedObject = @"org.openemu.Bind
 {
     OESystemPlugin *selectedPlugin;
     OEHIDEvent     *readingEvent;
+    CFAbsoluteTime readingEventTime;
     NSMutableSet   *ignoredEvents;
     id _eventMonitor;
 }
@@ -677,12 +678,13 @@ static CFHashCode _OEHIDEventHashSetCallback(OEHIDEvent *value)
     if([anEvent type] == OEHIDEventTypeKeyboard && ![self isKeyboardEventSelected])
         return NO;
 
-    // No event currently read, if it's not off state, store it and read it
-    if(readingEvent == nil)
+    // No event currently read or 100ms have passed, if it's not off state, store it and read it
+    if(readingEvent == nil || (readingEventTime + 0.1) < CFAbsoluteTimeGetCurrent())
     {
         // The event is not ignored but it's off, ignore it anyway
         if([anEvent hasOffState]) return NO;
 
+        readingEventTime = CFAbsoluteTimeGetCurrent();
         readingEvent = anEvent;
         return YES;
     }


### PR DESCRIPTION
Gamecube controller (via mayflash adapter) shoulder buttons have axis sensitivity such that halfway pressed = 0, towards fully pressed = positive, and towards unpressed = negative. When mapping controller inputs, on an input event, [`readingEvent` is set](https://github.com/OpenEmu/OpenEmu/blob/774496ff4b84084abd68d8bf5e3736041536fd89/OpenEmu/OEPrefControlsController.m#L680-L688) so that duplicate axis events are ignored. [This is reset](https://github.com/OpenEmu/OpenEmu/blob/774496ff4b84084abd68d8bf5e3736041536fd89/OpenEmu/OEPrefControlsController.m#L648-L657) when the corresponding 'Off' axis event happens ([null direction](https://github.com/OpenEmu/OpenEmu-SDK/blob/654e88ddaa0414fa5a8700c7bbebd709b6f8feb8/OpenEmuSystem/OEHIDEvent.m#L839)). However, the resting state of the gamecube shoulder button is not null. Thus, `readingEvent` will be stuck as the shoulder release event, and all future events are ignored.

This change ignores read events that happened more than 100 milliseconds ago (arbitrary number) on a different event (e.g. different axis or button press). It does this by recording the time of the last read event.