### PR TITLE
Implement QuickLook for the Screenshot collection

### DIFF
--- a/OpenEmu/OECollectionViewController.h
+++ b/OpenEmu/OECollectionViewController.h
@@ -82,6 +82,7 @@ extern NSString * const OELastCollectionViewKey;
 - (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel *)panel;
 - (NSInteger)numberOfPreviewItemsInPreviewPanel:(QLPreviewPanel *)panel;
 - (id <QLPreviewItem>)previewPanel:(QLPreviewPanel *)panel previewItemAtIndex:(NSInteger)index;
+- (NSInteger)imageBrowserViewIndexForPreviewItem:(id <QLPreviewItem>)item;
 
 #pragma mark -
 - (id <OECollectionViewItemProtocol>)representedObject;

--- a/OpenEmu/OECollectionViewController.h
+++ b/OpenEmu/OECollectionViewController.h
@@ -77,6 +77,7 @@ extern NSString * const OELastCollectionViewKey;
 - (NSMenu*)menuForItemsAtIndexes:(NSIndexSet*)indexes;
 
 #pragma mark - Quick Look
+- (void)refreshPreviewPanelIfNeeded;
 /* subclass these to implement quicklook for a specific collection */
 - (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel *)panel;
 - (NSInteger)numberOfPreviewItemsInPreviewPanel:(QLPreviewPanel *)panel;

--- a/OpenEmu/OECollectionViewController.h
+++ b/OpenEmu/OECollectionViewController.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSInteger, OECollectionViewControllerViewTag) {
 extern NSString * const OELastGridSizeKey;
 extern NSString * const OELastCollectionViewKey;
 
-@interface OECollectionViewController : NSViewController <OEBlankSlateViewDelegate, NSTableViewDelegate, NSTableViewDataSource, OELibrarySubviewController, OEGridViewDelegate, OEGridViewMenuSource>
+@interface OECollectionViewController : NSViewController <OEBlankSlateViewDelegate, NSTableViewDelegate, NSTableViewDataSource, OELibrarySubviewController, OEGridViewDelegate, OEGridViewMenuSource, QLPreviewPanelDelegate, QLPreviewPanelDataSource>
 
 /// If YES, the collection view controller is selected and visible to the user. Must be overridden by subclasses.
 @property (nonatomic, readonly) BOOL isSelected;
@@ -75,6 +75,12 @@ extern NSString * const OELastCollectionViewKey;
 
 #pragma mark - Context Menu
 - (NSMenu*)menuForItemsAtIndexes:(NSIndexSet*)indexes;
+
+#pragma mark - Quick Look
+/* subclass these to implement quicklook for a specific collection */
+- (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel *)panel;
+- (NSInteger)numberOfPreviewItemsInPreviewPanel:(QLPreviewPanel *)panel;
+- (id <QLPreviewItem>)previewPanel:(QLPreviewPanel *)panel previewItemAtIndex:(NSInteger)index;
 
 #pragma mark -
 - (id <OECollectionViewItemProtocol>)representedObject;

--- a/OpenEmu/OECollectionViewController.m
+++ b/OpenEmu/OECollectionViewController.m
@@ -637,6 +637,16 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
 }
 
 
+- (BOOL)previewPanel:(QLPreviewPanel *)panel handleEvent:(NSEvent *)event
+{
+  if ([event type] == NSEventTypeKeyDown || [event type] == NSEventTypeKeyUp) {
+    [self.gridView.window sendEvent:event];
+    return YES;
+  }
+  return NO;
+}
+
+
 #pragma mark - Core Data
 - (NSArray*)defaultSortDescriptors
 {

--- a/OpenEmu/OECollectionViewController.m
+++ b/OpenEmu/OECollectionViewController.m
@@ -596,6 +596,12 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
 }
 
 
+- (NSInteger)imageBrowserViewIndexForPreviewItem:(id <QLPreviewItem>)item
+{
+    return -1;
+}
+
+
 - (void)refreshPreviewPanelIfNeeded
 {
     QLPreviewPanel *panel;
@@ -605,6 +611,29 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
         if ([panel isVisible] && [panel delegate] == self)
             [panel reloadData];
     }
+}
+
+
+- (NSRect)previewPanel:(QLPreviewPanel *)panel sourceFrameOnScreenForPreviewItem:(id<QLPreviewItem>)item
+{
+    if (_selectedViewTag != OEGridViewTag)
+        return NSZeroRect;
+
+    NSInteger i = [self imageBrowserViewIndexForPreviewItem:item];
+    if (i < 0)
+        return NSZeroRect;
+    
+    IKImageBrowserCell *itemcell = [self.gridView cellForItemAtIndex:i];
+    NSRect thumbframe = [itemcell imageFrame];
+    NSScrollView *scrollv = [self.gridView enclosingScrollView];
+    thumbframe = [self.gridView convertRect:thumbframe toView:scrollv];
+    if (!NSContainsRect([scrollv bounds], thumbframe))
+        return NSZeroRect;
+    
+    NSWindow *w = [self.gridView window];
+    thumbframe = [scrollv convertRect:thumbframe toView:w.contentView];
+    NSRect screenrect = [w convertRectToScreen:thumbframe];
+    return screenrect;
 }
 
 

--- a/OpenEmu/OECollectionViewController.m
+++ b/OpenEmu/OECollectionViewController.m
@@ -596,6 +596,18 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
 }
 
 
+- (void)refreshPreviewPanelIfNeeded
+{
+    QLPreviewPanel *panel;
+  
+    if ([QLPreviewPanel sharedPreviewPanelExists]) {
+        panel = [QLPreviewPanel sharedPreviewPanel];
+        if ([panel isVisible] && [panel delegate] == self)
+            [panel reloadData];
+    }
+}
+
+
 #pragma mark - Core Data
 - (NSArray*)defaultSortDescriptors
 {

--- a/OpenEmu/OECollectionViewController.m
+++ b/OpenEmu/OECollectionViewController.m
@@ -541,6 +541,61 @@ static void *OEUserDefaultsDisplayGameTitleKVOContext = &OEUserDefaultsDisplayGa
 
 - (void)gridView:(OEGridView *)gridView setTitle:(NSString *)title forItemAtIndex:(NSInteger)index
 {}
+
+
+#pragma mark - Quick Look
+
+
+- (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel *)panel
+{
+    return NO;
+}
+
+
+- (void)beginPreviewPanelControl:(QLPreviewPanel *)panel
+{
+    // We are now responsible of the preview panel
+    panel.delegate = self;
+    panel.dataSource = self;
+}
+
+
+- (void)endPreviewPanelControl:(QLPreviewPanel *)panel
+{
+    // Lost responsibility on the preview panel
+}
+
+
+- (BOOL)toggleQuickLook
+{
+    QLPreviewPanel *panel;
+    
+    if (![self acceptsPreviewPanelControl:nil])
+        return NO;
+    
+    panel = [QLPreviewPanel sharedPreviewPanel];
+    if ([panel isVisible])
+        [panel orderOut:nil];
+    else
+        [panel makeKeyAndOrderFront:nil];
+    return YES;
+}
+
+
+- (NSInteger)numberOfPreviewItemsInPreviewPanel:(QLPreviewPanel *)panel
+{
+    [self doesNotImplementSelector:_cmd];
+    return 0;
+}
+
+
+- (id <QLPreviewItem>)previewPanel:(QLPreviewPanel *)panel previewItemAtIndex:(NSInteger)index
+{
+    [self doesNotImplementSelector:_cmd];
+    return nil;
+}
+
+
 #pragma mark - Core Data
 - (NSArray*)defaultSortDescriptors
 {

--- a/OpenEmu/OECollectionViewItemProtocol.h
+++ b/OpenEmu/OECollectionViewItemProtocol.h
@@ -29,5 +29,6 @@
 @protocol OECollectionViewItemProtocol <NSObject>
 - (BOOL)isCollectionEditable;
 @optional
+- (BOOL)collectionSupportsQuickLook;
 - (NSPredicate*)baseFilterPredicate;
 @end

--- a/OpenEmu/OEDBScreenshot.h
+++ b/OpenEmu/OEDBScreenshot.h
@@ -26,6 +26,7 @@
 
 @import Foundation;
 @import CoreData;
+@import Quartz;
 #import "OEDBItem.h"
 
 @class OEDBRom;
@@ -34,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString * const OEDBScreenshotImportRequired;
 
-@interface OEDBScreenshot: OEDBItem <NSPasteboardWriting>
+@interface OEDBScreenshot: OEDBItem <NSPasteboardWriting, QLPreviewItem>
 
 + (nullable instancetype)createObjectInContext:(NSManagedObjectContext *)context forROM:(OEDBRom *)rom withFile:(NSURL *)fileURL;
 - (void)updateFile;

--- a/OpenEmu/OEDBScreenshot.m
+++ b/OpenEmu/OEDBScreenshot.m
@@ -131,6 +131,23 @@ NSString * const OEDBScreenshotImportRequired = @"OEDBScreenshotImportRequired";
         self.URL = targetURL;
     }
 }
+
+
+#pragma mark - QLPreviewItem
+
+
+- (NSURL *)previewItemURL
+{
+    return [self URL];
+}
+
+
+- (NSString *)previewItemTitle
+{
+    return [self name];
+}
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OpenEmu/OEDBScreenshotsMedia.m
+++ b/OpenEmu/OEDBScreenshotsMedia.m
@@ -95,6 +95,11 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
 }
 
+- (BOOL)collectionSupportsQuickLook
+{
+    return YES;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OpenEmu/OEGridView.h
+++ b/OpenEmu/OEGridView.h
@@ -56,4 +56,6 @@ typedef enum
 
 @protocol OEGridViewDelegate <NSObject>
 - (void)gridView:(OEGridView*)gridView setTitle:(NSString*)title forItemAtIndex:(NSInteger)index;
+@optional
+- (BOOL)toggleQuickLook;
 @end

--- a/OpenEmu/OEGridView.m
+++ b/OpenEmu/OEGridView.m
@@ -444,7 +444,9 @@ static NSImage *lightingImage;
     switch (event.keyCode) {
         // original implementation does not pass space key to type-select
         case kVK_Space:
-            [self handleKeyInput:event character:' '];
+            if (![self.delegate respondsToSelector:@selector(toggleQuickLook)] ||
+                ![self.delegate toggleQuickLook])
+                [self handleKeyInput:event character:' '];
             break;
             
         case kVK_Return:

--- a/OpenEmu/OEMediaViewController.h
+++ b/OpenEmu/OEMediaViewController.h
@@ -25,6 +25,7 @@
  */
 
 @import Cocoa;
+@import Quartz;
 #import "OELibrarySubviewController.h"
 #import "OECollectionViewController.h"
 

--- a/OpenEmu/OEMediaViewController.m
+++ b/OpenEmu/OEMediaViewController.m
@@ -759,7 +759,44 @@ static NSString * const OESelectedMediaKey = @"_OESelectedMediaKey";
     return YES;
 }
 
+
+#pragma mark - QLPreviewPanelDataSource
+
+
+- (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel *)panel
+{
+    id<OECollectionViewItemProtocol> viewItem = [self representedObject];
+    if ([viewItem respondsToSelector:@selector(collectionSupportsQuickLook)])
+        return [viewItem collectionSupportsQuickLook];
+    return NO;
+}
+
+
+- (NSInteger)numberOfPreviewItemsInPreviewPanel:(QLPreviewPanel *)panel
+{
+    return self.selectionIndexes.count;
+}
+
+
+- (id <QLPreviewItem>)previewPanel:(QLPreviewPanel *)panel previewItemAtIndex:(NSInteger)index
+{
+    __block NSInteger reali = NSNotFound;
+    __block NSInteger i = index;
+    
+    [self.selectionIndexes enumerateRangesUsingBlock:^(NSRange range, BOOL * stop) {
+        if (i < range.length) {
+            *stop = YES;
+            reali = range.location + i;
+        } else {
+            i -= range.length;
+        }
+    }];
+    return reali == NSNotFound ? nil : self.items[reali];
+}
+
+
 @end
+
 
 #pragma mark - OESavedGamesDataWrapper
 

--- a/OpenEmu/OEMediaViewController.m
+++ b/OpenEmu/OEMediaViewController.m
@@ -797,6 +797,17 @@ static NSString * const OESelectedMediaKey = @"_OESelectedMediaKey";
 }
 
 
+- (NSInteger)imageBrowserViewIndexForPreviewItem:(id <QLPreviewItem>)item
+{
+    /* only search thru selected items because otherwise it might take forever */
+    NSInteger res =  [self.items indexOfObjectAtIndexes:self.selectionIndexes options:0 passingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        return item == obj;
+    }];
+    return res == NSNotFound ? self.selectionIndexes.firstIndex : res;
+}
+
+
+
 @end
 
 

--- a/OpenEmu/OEMediaViewController.m
+++ b/OpenEmu/OEMediaViewController.m
@@ -349,6 +349,8 @@ static NSString * const OESelectedMediaKey = @"_OESelectedMediaKey";
 
     NSString *defaultsKey = [[self OE_entityName] stringByAppendingString:OESelectedMediaKey];
     [[NSUserDefaults standardUserDefaults] setObject:archivableRepresentations forKey:defaultsKey];
+    
+    [self refreshPreviewPanelIfNeeded];
 }
 
 #pragma mark -


### PR DESCRIPTION
I found myself trying to use quicklook on the screenshots to no avail increasingly often, so I decided to implement it. It's useful for comparing similar screenshots, reading text on the screenshot if there's any, or just to have a closer look. QuickLook mode can be entered using the space bar, like in the Finder.

The meat of the implementation is in OECollectionViewController and OEMediaViewController. The QuickLook code should be easily maintainable in the event of a change in the implementation of OEGridView, and QuickLook support could be added easily for other media collections, even though at this moment it doesn't make much sense for any collection except for screenshots.

---

The only feature request I found related to QuickLook is #1012, where a feature request about adding quicklook to the game library was rejected. While I agree that it doesn't make much sense to have quicklook for game covers (even though the space bar does not open the games anymore), the reasoning "why don't you just increase the thumbnail size" could be applied to screenshots as well. But I don't think it's appropriate in this context. 

For once, increasing the thumbnail size is a global setting: to look closely at a screenshot, you could increase the thumbnail size, but then you have to dial it back where it was, which is annoying. Additionally, it's very hard or outright impossible to resize the screenshots to a pixel-perfect size with the thumbnail size slider, while quicklook enlarges the screenshot to its native size automatically. Covers are already scans, so it doesn't make much sense to enlarge them to 100% because their resolution is limited.