### PR TITLE
Attempt to fix #3365

### DIFF
--- a/OpenEmu/OEXPCGameCoreManager.m
+++ b/OpenEmu/OEXPCGameCoreManager.m
@@ -167,14 +167,11 @@
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_taskDidTerminate:) name:NSTaskDidTerminateNotification object:_backgroundProcessTask];
     
-    BOOL logCoreOutput = NO;
-#ifdef LogCoreOutput
-    logCoreOutput = YES;
-    /* not putting all the code here to make sure that it still compiles
-     * when somebody'll eventually need it */
-#endif
+    BOOL logCoreOutput = [[NSUserDefaults standardUserDefaults] boolForKey:@"OELogCoreOutput"];
 
     if (logCoreOutput) {
+        NSLog(@"Will log core output for %@", _processIdentifier);
+        
         _standardOutputPipe = [NSPipe pipe];
         int output_fildes = _standardOutputPipe.fileHandleForReading.fileDescriptor;
         

--- a/OpenEmu/OEXPCGameCoreManager.m
+++ b/OpenEmu/OEXPCGameCoreManager.m
@@ -177,7 +177,7 @@
         
         [_backgroundProcessTask setStandardOutput:_standardOutputPipe];
         dispatch_read(output_fildes, 72, dispatch_get_main_queue(), ^(dispatch_data_t data, int error){
-            [self _didReceiveData:(NSData*)data posixError:error fileDescriptor:output_fildes];
+            [self _didReceiveData:(NSData*)data posixError:error fileDescriptor:output_fildes name:@"stdout"];
         });
 
         _standardErrorPipe = [NSPipe pipe];
@@ -185,7 +185,7 @@
         
         [_backgroundProcessTask setStandardError:_standardErrorPipe];
         dispatch_read(error_fildes, 72, dispatch_get_main_queue(), ^(dispatch_data_t data, int error) {
-            [self _didReceiveData:(NSData*)data posixError:error fileDescriptor:error_fildes];
+            [self _didReceiveData:(NSData*)data posixError:error fileDescriptor:error_fildes name:@"stderr"];
         });
     } else {
         /* Do not even receive the core output if we're not doing anything with it
@@ -227,30 +227,30 @@
     [self selfRelease];
 }
 
-- (void)_didReceiveData:(NSData *)data posixError:(int)error fileDescriptor:(int)fildes
+- (void)_didReceiveData:(NSData *)data posixError:(int)error fileDescriptor:(int)fildes name:(NSString *)name
 {
     // If the length of the data is zero, then the task is basically over - there is nothing
     // more to get from the handle so we may as well shut down.
     if([data length] > 0 || error)
     {
         if (error) {
-            DLog(@"POSIX error while reading XPC helper streams: %d", error);
+            DLog(@"POSIX error while reading XPC helper %@: %d", name, error);
             // POSIX file read errors are not always fatal
         }
         
         // Send the data on to the controller; we can't just use +stringWithUTF8String: here
         // because -[data bytes] is not necessarily a properly terminated string.
         // -initWithData:encoding: on the other hand checks -[data length]
-        fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"background process error: %@: %@", [_processIdentifier substringToIndex:[_processIdentifier rangeOfString:@" # "].location], [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]] UTF8String]);
+        fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"background process %@: %@: %@", name, [_processIdentifier substringToIndex:[_processIdentifier rangeOfString:@" # "].location], [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]] UTF8String]);
 
         dispatch_read(fildes, 72, dispatch_get_main_queue(), ^(dispatch_data_t data, int error) {
-            [self _didReceiveData:(NSData*)data posixError:error fileDescriptor:fildes];
+            [self _didReceiveData:(NSData*)data posixError:error fileDescriptor:fildes name:name];
         });
     }
     else
     {
         // We're finished here
-        DLog(@"background process %@: stderr EOF", _processIdentifier);
+        DLog(@"background process %@: %@ EOF", _processIdentifier, name);
     }
 }
 

--- a/OpenEmu/OEXPCGameCoreManager.m
+++ b/OpenEmu/OEXPCGameCoreManager.m
@@ -166,18 +166,36 @@
     [_backgroundProcessTask setArguments:@[ [configuration agentServiceNameProcessArgument], [configuration processIdentifierArgumentForIdentifier:_processIdentifier] ]];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_taskDidTerminate:) name:NSTaskDidTerminateNotification object:_backgroundProcessTask];
+    
+    BOOL logCoreOutput = NO;
+#ifdef LogCoreOutput
+    logCoreOutput = YES;
+    /* not putting all the code here to make sure that it still compiles
+     * when somebody'll eventually need it */
+#endif
 
-    _standardOutputPipe = [NSPipe pipe];
-    [_backgroundProcessTask setStandardOutput:_standardOutputPipe];
+    if (logCoreOutput) {
+        _standardOutputPipe = [NSPipe pipe];
+        int output_fildes = _standardOutputPipe.fileHandleForReading.fileDescriptor;
+        
+        [_backgroundProcessTask setStandardOutput:_standardOutputPipe];
+        dispatch_read(output_fildes, 72, dispatch_get_main_queue(), ^(dispatch_data_t data, int error){
+            [self _didReceiveData:(NSData*)data posixError:error fileDescriptor:output_fildes];
+        });
 
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_didReceiveData:) name:NSFileHandleReadCompletionNotification object:[_standardOutputPipe fileHandleForReading]];
-    [[_standardOutputPipe fileHandleForReading] readInBackgroundAndNotify];
-
-    _standardErrorPipe = [NSPipe pipe];
-    [_backgroundProcessTask setStandardError:_standardErrorPipe];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_didReceiveErrorData:) name:NSFileHandleReadCompletionNotification object:[_standardErrorPipe fileHandleForReading]];
-    [[_standardErrorPipe fileHandleForReading] readInBackgroundAndNotify];
+        _standardErrorPipe = [NSPipe pipe];
+        int error_fildes = _standardErrorPipe.fileHandleForReading.fileDescriptor;
+        
+        [_backgroundProcessTask setStandardError:_standardErrorPipe];
+        dispatch_read(error_fildes, 72, dispatch_get_main_queue(), ^(dispatch_data_t data, int error) {
+            [self _didReceiveData:(NSData*)data posixError:error fileDescriptor:error_fildes];
+        });
+    } else {
+        /* Do not even receive the core output if we're not doing anything with it
+         * to save CPU time */
+        [_backgroundProcessTask setStandardOutput:[NSFileHandle fileHandleWithNullDevice]];
+        [_backgroundProcessTask setStandardError:[NSFileHandle fileHandleWithNullDevice]];
+    }
 
     [_backgroundProcessTask launch];
 }
@@ -204,7 +222,6 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 
     _backgroundProcessTask = nil;
-    _processIdentifier     = nil;
     _standardOutputPipe    = nil;
     _standardErrorPipe     = nil;
 
@@ -213,50 +230,32 @@
     [self selfRelease];
 }
 
-- (void)_didReceiveErrorData:(NSNotification *)notification
+- (void)_didReceiveData:(NSData *)data posixError:(int)error fileDescriptor:(int)fildes
 {
-    NSData *data = [[notification userInfo] objectForKey:NSFileHandleNotificationDataItem];
-
     // If the length of the data is zero, then the task is basically over - there is nothing
     // more to get from the handle so we may as well shut down.
-    if([data length] > 0)
+    if([data length] > 0 || error)
     {
+        if (error) {
+            DLog(@"POSIX error while reading XPC helper streams: %d", error);
+            // POSIX file read errors are not always fatal
+        }
+        
         // Send the data on to the controller; we can't just use +stringWithUTF8String: here
         // because -[data bytes] is not necessarily a properly terminated string.
         // -initWithData:encoding: on the other hand checks -[data length]
-#ifdef LogCoreOutput
         fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"background process error: %@: %@", [_processIdentifier substringToIndex:[_processIdentifier rangeOfString:@" # "].location], [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]] UTF8String]);
-#endif
-        [[notification object] readInBackgroundAndNotify];
+
+        dispatch_read(fildes, 72, dispatch_get_main_queue(), ^(dispatch_data_t data, int error) {
+            [self _didReceiveData:(NSData*)data posixError:error fileDescriptor:fildes];
+        });
     }
     else
     {
         // We're finished here
-        [self stop];
+        DLog(@"background process %@: stderr EOF", _processIdentifier);
     }
 }
 
-- (void)_didReceiveData:(NSNotification *)notification
-{
-    NSData *data = [[notification userInfo] objectForKey:NSFileHandleNotificationDataItem];
-
-    // If the length of the data is zero, then the task is basically over - there is nothing
-    // more to get from the handle so we may as well shut down.
-    if([data length] > 0)
-    {
-        // Send the data on to the controller; we can't just use +stringWithUTF8String: here
-        // because -[data bytes] is not necessarily a properly terminated string.
-        // -initWithData:encoding: on the other hand checks -[data length]
-#ifdef LogCoreOutput
-        fprintf(stderr, "%s\n", [[NSString stringWithFormat:@"background process error: %@: %@", [_processIdentifier substringToIndex:[_processIdentifier rangeOfString:@" # "].location], [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]] UTF8String]);
-#endif
-        [[notification object] readInBackgroundAndNotify];
-    }
-    else
-    {
-        // We're finished here
-        [self stop];
-    }
-}
 
 @end


### PR DESCRIPTION
This PR tries to fix #3365 by avoiding the use of NSFileHandle to read the stdout and stdin of the XPC helper, and using dispatch_read instead. I've tested this patch for 3 hours (which is longer than the usual period the bug takes to manifest on my system) and no hangs occurred.

As with all bugs that happen after some unspecified time has passed, it's impossible to be absolutely sure it is fixed, so more testing is always welcome.

Curiously, it seems that dispatch_read is actually the underlying API used by NSFileHandle to read the stream, but if I use it manually (as in this patch) the bug seems to not occur, which makes me think it is related to the change to NSFileHandle mentioned in the [release notes for 10.13 Foundation](https://developer.apple.com/library/content/releasenotes/Foundation/RN-Foundation/index.html).

I did another change to make XPC helper output logging sightly more useful. Instead of using a define to enable/disable it, now
- it is enabled by setting the NSUserDefault "OELogCoreOutput" to YES, which can be done from the command line or with the ``defaults`` tool without recompiling
- if it is disabled, the stdout and stderr of the XPC helper are actually set to /dev/null, which not only makes #3365 impossible, but also allows us to save CPU time in the main process. This CPU time reduction is fairly concrete, especially since after OpenEmu/OpenEmu-SDK@62c7436 and 8bf75466 the amount of logging from the core process increased a lot. 