### PR TITLE
Localize the play time shown in the game library list view.

### DIFF
--- a/OpenEmu/OEDBDataSourceAdditions.m
+++ b/OpenEmu/OEDBDataSourceAdditions.m
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSDateFormatter *_OEListViewDateFormatter;
 static void OE_initOEListViewDateFormatter(void) __attribute__((constructor));
-static NSString * OE_stringFromElapsedTime(NSTimeInterval);
+static NSString * OE_localizedStringFromElapsedTime(NSTimeInterval);
 
 NSString * const OECoverGridViewAutoDownloadEnabledKey = @"OECoverGridViewAutoDownloadEnabledKey";
 
@@ -248,7 +248,7 @@ NSString * const OECoverGridViewAutoDownloadEnabledKey = @"OECoverGridViewAutoDo
 
 - (NSString *)listViewPlayTime
 {
-    return (self.playTime.doubleValue > 0 ? OE_stringFromElapsedTime(self.playTime.doubleValue) : @"");
+    return (self.playTime.doubleValue > 0 ? OE_localizedStringFromElapsedTime(self.playTime.doubleValue) : @"");
 }
 
 static void OE_initOEListViewDateFormatter(void)
@@ -261,44 +261,17 @@ static void OE_initOEListViewDateFormatter(void)
     }
 }
 
-NSString * OE_stringFromElapsedTime(NSTimeInterval timeInterval)
+NSString * OE_localizedStringFromElapsedTime(NSTimeInterval timeInterval)
 {
-    const int oneMinuteInSeconds = 60;
-    const int oneHourInSeconds   = 60 * oneMinuteInSeconds;
-    const int oneDayInSeconds    = 24 * oneHourInSeconds;
-
-    NSString *dayUnit    = @"d";
-    NSString *hourUnit   = @"h";
-    NSString *minuteUnit = @"m";
-    NSString *secondUnit = @"s";
-
-    NSMutableString *s = [NSMutableString new];
-    NSUInteger       t = ABS(timeInterval);
-
-    if(t > oneDayInSeconds)
-    {
-        [s appendFormat:@"%lu%@", (unsigned long)(t / oneDayInSeconds), dayUnit];
-        t %= oneDayInSeconds;
-    }
-
-    if(t > oneHourInSeconds)
-    {
-        NSString *format = ([s length] > 0 ? @"%02u%@" : @"%u%@");
-        [s appendFormat:format, (unsigned)(t / oneHourInSeconds), hourUnit];
-        t %= oneHourInSeconds;
-    }
-
-    if(t > oneMinuteInSeconds)
-    {
-        NSString *format = ([s length] > 0 ? @"%02u%@" : @"%u%@");
-        [s appendFormat:format, (unsigned)(t / oneMinuteInSeconds), minuteUnit];
-        t %= oneMinuteInSeconds;
-    }
-
-    NSString *format = ([s length] > 0 ? @"%02u%@" : @"%u%@");
-    [s appendFormat:format, (unsigned)t, secondUnit];
-
-    return s;
+    static NSDateComponentsFormatter *dcf;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        dcf = [[NSDateComponentsFormatter alloc] init];
+        [dcf setUnitsStyle:NSDateComponentsFormatterUnitsStyleAbbreviated];
+        [dcf setAllowedUnits:NSCalendarUnitSecond + NSCalendarUnitMinute + NSCalendarUnitHour + NSCalendarUnitDay];
+    });
+    
+    return [dcf stringFromTimeInterval:timeInterval];
 }
 
 @end


### PR DESCRIPTION
I noticed that the play time shown in the game library was formatted in the same way regardless of the language; since I had nothing better to do I fixed it.

When the language is English, the only difference between the output of the old code and NSDateComponentsFormatter is that NSDateComponentsFormatter adds spaces between the components, while the old formatting code did not. For other languages the output now matches the local conventions.

NSDateComponentsFormatter is a newish API, but it is supported on 10.10+, thus it does not affect the current requirement of macOS 10.11+.