### PR TITLE
fix typo on Choose OpenEmu Library window

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -450,7 +450,7 @@ class AppDelegate: NSDocumentController {
         // Set up alert with "Quit", "Select", and "Create".
         let alert = OEHUDAlert()
         
-        alert.headlineText = NSLocalizedString("Chose OpenEmu Library", comment: "")
+        alert.headlineText = NSLocalizedString("Choose OpenEmu Library", comment: "")
         alert.messageText = NSLocalizedString("OpenEmu needs a library to continue. You may choose an existing OpenEmu library or create a new one", comment: "")
         
         alert.defaultButtonTitle = NSLocalizedString("Choose Library…", comment: "")


### PR DESCRIPTION
This PR corrects the typo shown in the following screen shot:

<img width="423" src="https://user-images.githubusercontent.com/160164/56095014-db544700-5f1b-11e9-8b11-58e281db2556.png">
