### PR TITLE
Feature: Key bindings to increase / decrease emulation speed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "files.associations": {
+    "__locale": "cpp",
+    "locale": "cpp",
+    "thread": "cpp"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "files.associations": {
-    "__locale": "cpp",
-    "locale": "cpp",
-    "thread": "cpp"
-  }
-}

--- a/OpenEmu/OpenEmuHelperApp.m
+++ b/OpenEmu/OpenEmuHelperApp.m
@@ -898,6 +898,11 @@ extern NSString * const kCAContextCIFilterBehavior;
     [_gameCoreOwner fastForwardGameplay:enable];
 }
 
+- (void)fastForwardAtSpeed:(CGFloat)value
+{
+
+}
+
 - (void)rewindGameplay:(BOOL)enable
 {
     // TODO: technically a data race, but it is only updating a single NSInteger

--- a/OpenEmu/OpenEmuHelperApp.m
+++ b/OpenEmu/OpenEmuHelperApp.m
@@ -898,11 +898,6 @@ extern NSString * const kCAContextCIFilterBehavior;
     [_gameCoreOwner fastForwardGameplay:enable];
 }
 
-- (void)fastForwardAtSpeed:(CGFloat)value
-{
-
-}
-
 - (void)rewindGameplay:(BOOL)enable
 {
     // TODO: technically a data race, but it is only updating a single NSInteger


### PR DESCRIPTION
Adds in a new feature to increase or decrease emulation speed. Works similar to fast forward, except each time you press the key it will adjust the speed by 25% and keeps it there so you don't have to keep any key pressed down. Max game speed is 5x speed (same as fast forward) and the lowest you can go is 0.25x speed.

Two new key bindings have been added for "increase game speed" and "decrease game speed" to support this.