### PR TITLE
Fix a Crash in Preferences > Controls on N64

### DIFF
--- a/OpenEmu/OEPopUpButtonCell.m
+++ b/OpenEmu/OEPopUpButtonCell.m
@@ -121,7 +121,9 @@
         NSRect textRect  = [self titleRectForBounds:cellFrame];
         NSRect imageRect = [self imageRectForBounds:cellFrame];
 
-        if(!NSIsEmptyRect(textRect))  [self drawTitle:[self attributedTitle] withFrame:textRect inView:controlView];
+        if(!NSIsEmptyRect(textRect) && [[self attributedTitle] length] > 0) {
+          [self drawTitle:[self attributedTitle] withFrame:textRect inView:controlView];
+        }
         if(!NSIsEmptyRect(imageRect)) [self drawImage:[self image] withFrame:imageRect inView:controlView];
     }
     else

--- a/OpenEmu/OEPopUpButtonCell.m
+++ b/OpenEmu/OEPopUpButtonCell.m
@@ -122,7 +122,7 @@
         NSRect imageRect = [self imageRectForBounds:cellFrame];
 
         if(!NSIsEmptyRect(textRect) && [[self attributedTitle] length] > 0) {
-          [self drawTitle:[self attributedTitle] withFrame:textRect inView:controlView];
+            [self drawTitle:[self attributedTitle] withFrame:textRect inView:controlView];
         }
         if(!NSIsEmptyRect(imageRect)) [self drawImage:[self image] withFrame:imageRect inView:controlView];
     }


### PR DESCRIPTION
## Description

Fixes an issue that causes a crash on OpenEmu 2.1.1 while navigating to Preferences > Controls for N64. The error is caused by a call to `OEPopUpButtonCell`'s `attributedTitle` method returning an empty `NSAttributedString`. The resulting exception message is `Crashing on exception: NSMutableRLEArray objectAtIndex:effectiveRange:: Out of bounds`

Initially reported on [Reddit](https://www.reddit.com/r/OpenEmu/comments/dqmycf/openemu_211_released/f6ife0k)