### PR TITLE
Fix Swift compile failure due to wrong type

### DIFF
--- a/OpenEmu/AvailableLibrariesViewController.swift
+++ b/OpenEmu/AvailableLibrariesViewController.swift
@@ -25,7 +25,7 @@
 import Cocoa
 
 extension NSUserInterfaceItemIdentifier {
-    static let availableLibrariesCollectionViewItem: NSUserInterfaceItemIdentifier = "AvailableLibrariesCollectionViewItem"
+    static let availableLibrariesCollectionViewItem: NSUserInterfaceItemIdentifier = NSUserInterfaceItemIdentifier("AvailableLibrariesCollectionViewItem")
 }
 
 @objc(OEAvailableLibrariesViewController)


### PR DESCRIPTION
Fixes compilation failure due to `availableLibrariesCollectionViewItem` got initialized with a String value.