### PR TITLE
Remove glowCell from OEBlankSlateView

### DIFF
--- a/OpenEmu/OEBlankSlateView.m
+++ b/OpenEmu/OEBlankSlateView.m
@@ -410,32 +410,6 @@ NSString * const OECDBasedGamesUserGuideURLString = @"https://github.com/OpenEmu
                                     NSShadowAttributeName : shadow,
                                     NSForegroundColorAttributeName : [NSColor colorWithDeviceWhite:0.11 alpha:1.0] };
 
-    OECenteredTextFieldCell *glowCell = [[OECenteredTextFieldCell alloc] initTextCell:@""];
-    
-    shadow = [[NSShadow alloc] init];
-    shadow.shadowColor = [NSColor colorWithDeviceWhite:1.0 alpha:0.05];
-    shadow.shadowOffset = NSMakeSize(0.0, 0.0);
-    shadow.shadowBlurRadius = 2.0;
-
-    glowCell.textAttributes = @{ NSFontAttributeName : [NSFont boldSystemFontOfSize:18.0],
-                                 NSParagraphStyleAttributeName : style,
-                                 NSShadowAttributeName : shadow,
-                                 NSForegroundColorAttributeName : [NSColor colorWithDeviceWhite:0.11 alpha:0.0] };
-
-    NSRect dragAndDropHereOuterGlowRect = NSMakeRect(0.0,
-                                              NSHeight(containerFrame) - 25.0 - OEBlankSlateBoxTextToTop,
-                                              NSWidth(containerFrame),
-                                              25.0);
-    
-    NSTextField *dragAndDropHereOuterGlowField = [[NSTextField alloc] initWithFrame:dragAndDropHereOuterGlowRect];
-    
-    dragAndDropHereOuterGlowField.cell = glowCell;
-    dragAndDropHereOuterGlowField.stringValue = text;
-    dragAndDropHereOuterGlowField.editable = NO;
-    dragAndDropHereOuterGlowField.selectable = NO;
-    dragAndDropHereOuterGlowField.drawsBackground = NO;
-    dragAndDropHereOuterGlowField.bezeled = NO;
-
     NSRect dragAndDropHereRect = NSMakeRect(0.0,
                                             NSHeight(containerFrame) - 25.0 - OEBlankSlateBoxTextToTop,
                                             NSWidth(containerFrame),
@@ -451,7 +425,6 @@ NSString * const OECDBasedGamesUserGuideURLString = @"https://github.com/OpenEmu
     dragAndDropHereField.bezeled = NO;
     
     [container addSubview:dragAndDropHereField];
-    [container addSubview:dragAndDropHereOuterGlowField];
 }
 
 - (void)setRepresentedMediaType:(id <OESidebarItem>)item


### PR DESCRIPTION
Seems like glowCell for "Drag & Drop Games Here" label serves no purpose anymore and is only visible on 10.14+ only if you have subpixel antialiasing reenabled with `defaults write -g CGFontRenderingFontSmoothingDisabled -bool NO`, this commit removes it. 
Fixes #3920, #4074.

Default font settings, before removal:
![Screenshot 2020-03-25 at 01 34 33](https://user-images.githubusercontent.com/16036254/77487516-510aa780-6e3b-11ea-98a0-eb4a8036b803.png)
Default font settings, after removal:
![Screenshot 2020-03-25 at 01 34 50](https://user-images.githubusercontent.com/16036254/77487521-54059800-6e3b-11ea-90ea-f0e4e0ca3e95.png)
Reenabled subpixel antialiasing, before removal:
![Screenshot 2020-03-25 at 01 41 56](https://user-images.githubusercontent.com/16036254/77487560-6f70a300-6e3b-11ea-92b6-03c5c3c6dc8d.png)
Reenabled subpixel antialiasing, after removal:
![Screenshot 2020-03-25 at 01 41 31](https://user-images.githubusercontent.com/16036254/77487572-7c8d9200-6e3b-11ea-9df4-a523ac95b5d7.png)

