### PR TITLE
Resolve symlinks in stateFolderURL

### DIFF
--- a/OpenEmu/OELibraryDatabase.m
+++ b/OpenEmu/OELibraryDatabase.m
@@ -786,6 +786,9 @@ static OELibraryDatabase * _Nullable defaultDatabase = nil;
     result = [result URLByAppendingPathComponent:@"OpenEmu" isDirectory:YES];
     result = [result URLByAppendingPathComponent:saveStateFolderName isDirectory:YES];
 
+    // In case one of the appended components is a symlink.
+    result = [result URLByResolvingSymlinksInPath];
+
     // [[NSFileManager defaultManager] createDirectoryAtURL:result withIntermediateDirectories:YES attributes:nil error:nil];
 
     return result;


### PR DESCRIPTION
This patch fixes a non-critical but annoying (to me) problem where duplicate `OEDBSaveState` records are created whenever a change to a `oesavestate` file is detected iff that file is inside a symlinked directory.

## Reproduce

Back up your stuff and run:

```sh
mv $HOME/Library/Application\ Support/OpenEmu ~/.openemu
ln -s ~/.openemu $HOME/Library/Application\ Support/OpenEmu
```

Launch OpenEmu, and switch to the Saved States view. Should look fine so far.
Now touch a saved state. Here's an example from my machine:

```sh
touch .openemu/Save\ States/SuperNES/ABC/Auto\ Save\ State.oesavestate
touch  $HOME/Library/Application\ Support/OpenEmu/Save\ States/SuperNES/ABC/Auto\ Save\ State.oesavestate
```

Behold, a second entry in the Saved States view. The file has not been duplicated, there's just a second record been spawned. Repeat the touch as many times as you wish, to create more duplicates. It works whether you touch the file via the symlink or not. The deduplicates all launch as expected when double-clicked in OpenEmu, and persist between restarts.

## Explanation

When the file changes, the callback `fsBlock` in `OE_setupStateWatcher` (in OELibraryDatabase.m) is called. Place a breakpoint on [line 412](https://github.com/OpenEmu/OpenEmu/blob/5e7fc7d71ab10b83a54dff9648055865f09fb669/OpenEmu/OELibraryDatabase.m#L412) and you will see that `path` contains the filename with symlinks _already resolved_. (In my example above, it contains `.openemu` and not `Library`.) Skip past some irrelevant stuff, and moveToDefaultLocation [is called](https://github.com/OpenEmu/OpenEmu/blob/5e7fc7d71ab10b83a54dff9648055865f09fb669/OpenEmu/OEDBSaveState.m#L162) with that path. (It actually seems to be called twice, for reasons unclear to me.) Put a breakpoint on [line 542](https://github.com/OpenEmu/OpenEmu/blob/5e7fc7d71ab10b83a54dff9648055865f09fb669/OpenEmu/OEDBSaveState.m#L542) to see the problem:

```
currentURL = file:///Users/adammck/.openemu/Save%20States/ ...
url = file:///Users/adammck/Library/Application%20Support/OpenEmu/Save%20States/ ...
```

OpenEmu has decided to move the file from its actual location to... the same place, just via the symlink. This succeeds, so it sets self.URL to `url` and saves the record. This works, because the file can be accessed either way. However, we have no record of the files actual filename. So when the file changes again, and the fsBlock callback is called again, we repeat the process, and the record is saved again.

## Fix

As you can see from the patch, the fix is a one-liner. When building paths to the Save States directory, we must **resolve symlinks first**, so that the rest of the stuff sees that we already know about the file. I've tested this out pretty thoroughly and it seems to work, but I'm not familiar with the codebase (or macOS development in general) so you may be able to think of some downside I missed.

There are various other ways to fix this, but this was the simplest I could think of. The same problem sort of exists for screenshots and roms, but we only seem to do the filesystem-watching thing for saved states, so it's not a problem in practice. Probably all of the file-handling stuff should be refactored to do this path resolving in one place, but I didn't want to come at you with a huge patch for this obscure problem.

---

I believe this is the root cause of #4277, because the directory is symlinked into iCloud drive, which touches the file as it syncs it, which causes OpenEmu to "move" it, which causes iCloud drive to touch it again, etc etc. I'm aware that Dropbox/iCloud sync is not recommended, but the problem exists independent of that.
