### PR TITLE
Addition of OEPersistentCheats class and hooks to the load/save part …

### DIFF
--- a/OpenEmu/OEGameControlsBar.h
+++ b/OpenEmu/OEGameControlsBar.h
@@ -35,6 +35,7 @@ extern NSString *const OEGameControlsBarShowsAudioOutput;
 
 @class OEGameViewController;
 @interface OEGameControlsBar : NSWindow <NSMenuDelegate>
+@property (strong) NSMutableArray *cheats;
 
 - (id)initWithGameViewController:(OEGameViewController*)controller;
 

--- a/OpenEmu/OEGameControlsBar.m
+++ b/OpenEmu/OEGameControlsBar.m
@@ -25,7 +25,7 @@
  */
 
 #import "OEGameControlsBar.h"
-
+#import "OEPErsistentCheats.h"
 #import "OEDBRom.h"
 
 @import OpenEmuKit;
@@ -54,7 +54,6 @@ NSString *const OEGameControlsBarShowsAudioOutput       = @"HUDBarShowAudioOutpu
 @interface OEGameControlsBar () <CAAnimationDelegate>
 @property (strong) id eventMonitor;
 @property (strong) NSTimer *fadeTimer;
-@property (strong) NSMutableArray *cheats;
 @property          NSMutableSet *openMenus;
 @property          BOOL cheatsLoaded;
 
@@ -174,6 +173,11 @@ NSString *const OEGameControlsBarShowsAudioOutput       = @"HUDBarShowAudioOutpu
     _fadeTimer = nil;
     _gameViewController = nil;
 
+    // Record cheat state.
+    BOOL saveResult = [OEPErsistentCheats persistROMCheats:self.gameViewController.document.rom.URL
+                                             withCheatList:self.cheats];
+    NSLog(@"%s -- result of saveResult == %@", __PRETTY_FUNCTION__, @(saveResult));
+    
     [NSEvent removeMonitor:_eventMonitor];
 
     _gameWindow = nil;
@@ -199,6 +203,11 @@ NSString *const OEGameControlsBarShowsAudioOutput       = @"HUDBarShowAudioOutpu
         {
             OECheats *cheatsXML = [[OECheats alloc] initWithMd5Hash:md5Hash];
             _cheats             = [cheatsXML.allCheats mutableCopy];
+            
+            _cheats = [NSMutableArray array]; // Disable lame XML cheats, which has like 5 games of codes.
+            // Merge any persisted cheats.
+            NSArray *persistedCheats = [OEPErsistentCheats loadROMCheats:self.gameViewController.document.rom.URL];
+            [_cheats addObjectsFromArray:persistedCheats];
             _cheatsLoaded       = YES;
         }
     }

--- a/OpenEmu/OEGameViewController.m
+++ b/OpenEmu/OEGameViewController.m
@@ -25,6 +25,7 @@
  */
 
 #import "OEGameViewController.h"
+#import "OEPErsistentCheats.h"
 
 @import OpenEmuKit;
 @import OpenEmuSystem;
@@ -172,6 +173,9 @@ CGFloat const DEFAULT_HEIGHT = 300.0;
 {
     [super viewWillDisappear];
 
+    BOOL saveResult = [OEPErsistentCheats persistROMCheats:self.document.rom.URL
+                                             withCheatList:_controlsWindow.cheats];
+    NSLog(@"%s -- result of saveResult == %@", __PRETTY_FUNCTION__, @(saveResult));
     [_controlsWindow hideAnimated:NO];
     [_controlsWindow setGameWindow:nil];
     [[self OE_rootWindow] removeChildWindow:_controlsWindow];

--- a/OpenEmu/OEPErsistentCheats.h
+++ b/OpenEmu/OEPErsistentCheats.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2021, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OEPErsistentCheats : NSObject
++(BOOL)persistROMCheats:(NSURL *) romPath
+          withCheatList:(NSMutableArray *) cheatsList;
++(NSArray *)loadROMCheats:(NSURL *) romPath;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OpenEmu/OEPErsistentCheats.m
+++ b/OpenEmu/OEPErsistentCheats.m
@@ -1,0 +1,65 @@
+// Copyright (c) 2021, OpenEmu Team
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the OpenEmu Team nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY OpenEmu Team ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL OpenEmu Team BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import "OEPErsistentCheats.h"
+#import "OEDBRom.h"
+
+@implementation OEPErsistentCheats
++(BOOL)persistROMCheats:(NSURL *) romPath
+          withCheatList:(NSMutableArray *) cheatsList
+{
+    NSURL *plistCheatsForGameURL = [romPath URLByDeletingPathExtension];
+    plistCheatsForGameURL = [plistCheatsForGameURL URLByAppendingPathExtension:@"cheatsPlist"];
+    NSLog(@"--  Current Cheats URL => %@", plistCheatsForGameURL);
+    NSError *error;
+    NSData *plistData = [NSPropertyListSerialization dataWithPropertyList:cheatsList
+                                                                   format:NSPropertyListXMLFormat_v1_0
+                                                                  options:0
+                                                                    error:&error];
+    BOOL saveResult = [plistData writeToURL:plistCheatsForGameURL atomically:YES];
+    NSLog(@"%s -- result of saveResult == %@", __PRETTY_FUNCTION__, @(saveResult));
+    return saveResult;
+}
+
++(NSArray *)loadROMCheats:(NSURL *) romPath
+{
+    NSURL *plistCheatsForGameURL = [romPath URLByDeletingPathExtension];
+    plistCheatsForGameURL = [plistCheatsForGameURL URLByAppendingPathExtension:@"cheatsPlist"];
+    NSLog(@"--  Current Cheats URL => %@", plistCheatsForGameURL);
+    
+    if([[NSFileManager defaultManager] fileExistsAtPath:[plistCheatsForGameURL path]])
+    {
+        NSError *error;
+        NSArray *plistCheats = [NSPropertyListSerialization propertyListWithData:[NSData dataWithContentsOfURL:plistCheatsForGameURL]
+                                                                   options:NSPropertyListImmutable
+                                                                    format:NULL
+                                                                      error:&error];
+        NSLog(@"%s -- plistCheats = %@", __PRETTY_FUNCTION__, plistCheats);
+        return plistCheats;
+    }
+    return @[];
+}
+
+@end
+

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -716,6 +716,7 @@
 		EF2FDBED14CFFE1B002A64F2 /* ControlsKeySeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D9991E146F40DA004409DC /* ControlsKeySeparatorView.swift */; };
 		EFBD5D7814EFE19A00FBD1E0 /* NSColor+OEAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBD5D7714EFE19A00FBD1E0 /* NSColor+OEAdditions.swift */; };
 		EFBD5D7F14EFE26300FBD1E0 /* OEGridView.m in Sources */ = {isa = PBXBuildFile; fileRef = EFBD5D7C14EFE26300FBD1E0 /* OEGridView.m */; };
+		F0F2EC632633064900E88054 /* OEPErsistentCheats.m in Sources */ = {isa = PBXBuildFile; fileRef = F0F2EC622633064900E88054 /* OEPErsistentCheats.m */; };
 		FE6310A1187F099800D8AE07 /* MSX.oesystemplugin in CopyFiles */ = {isa = PBXBuildFile; fileRef = FEB6625B187B791800D14713 /* MSX.oesystemplugin */; };
 		FEB66268187B792700D14713 /* OEMSXSystemController.m in Sources */ = {isa = PBXBuildFile; fileRef = FEB66251187B62CA00D14713 /* OEMSXSystemController.m */; };
 		FEB66269187B792700D14713 /* OEMSXSystemResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = FEB66254187B751700D14713 /* OEMSXSystemResponder.m */; };
@@ -2126,6 +2127,8 @@
 		EFBD5D7714EFE19A00FBD1E0 /* NSColor+OEAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSColor+OEAdditions.swift"; sourceTree = "<group>"; };
 		EFBD5D7B14EFE26300FBD1E0 /* OEGridView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEGridView.h; sourceTree = "<group>"; };
 		EFBD5D7C14EFE26300FBD1E0 /* OEGridView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEGridView.m; sourceTree = "<group>"; };
+		F0F2EC612633064900E88054 /* OEPErsistentCheats.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OEPErsistentCheats.h; sourceTree = "<group>"; };
+		F0F2EC622633064900E88054 /* OEPErsistentCheats.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OEPErsistentCheats.m; sourceTree = "<group>"; };
 		F1A2C86D1AAD0B3A00A17C80 /* fr */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F1A2C86E1AAD0B3B00A17C80 /* fr */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F1A2C86F1AAD0B3B00A17C80 /* fr */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ControlLabels.strings; sourceTree = "<group>"; };
@@ -3559,6 +3562,8 @@
 			children = (
 				5A575DFA1E92B6CE00491B0D /* BIOSFile.swift */,
 				5A575DFC1E92D23600491B0D /* Cheats.swift */,
+				F0F2EC612633064900E88054 /* OEPErsistentCheats.h */,
+				F0F2EC622633064900E88054 /* OEPErsistentCheats.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -6585,6 +6590,7 @@
 				5A3DB1691D8C93C3009445EC /* PreferencesControlsBox.swift in Sources */,
 				53439AA213B92C9D005C0CC8 /* OEDBGame.m in Sources */,
 				53439AA313B92C9D005C0CC8 /* OEDBSystem.m in Sources */,
+				F0F2EC632633064900E88054 /* OEPErsistentCheats.m in Sources */,
 				5A9606EA1C0BD2BD0089B494 /* DLog.swift in Sources */,
 				8306CD3E1BD3DB180025BC6C /* OEGameCollectionViewController.m in Sources */,
 				53439AAB13B92CE6005C0CC8 /* OECollectionViewController.m in Sources */,


### PR DESCRIPTION
…+ disable old CheatsXML Swift hook.

I've been wanting to have cheats persist in OpenEMU for a while, so I wrote a small patch to add that feature.