### PR TITLE
Fix: Allow longer cheat codes

### DIFF
--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -1243,7 +1243,7 @@ final class OEGameDocument: NSDocument {
         alert.showsSuppressionButton = true
         alert.suppressionLabelText = NSLocalizedString("Enable now", comment: "Cheats button label")
         
-        alert.inputLimit = 1000
+        alert.inputLimit = 1350
         
         if alert.runModal() == .alertFirstButtonReturn {
             var enabled: Bool


### PR DESCRIPTION
Issue #4570 had a cheat code for Pokemon Black 2 which was 1097 
characters long and #4625 had a cheat code for Dragon Quest IX which
which was 1314 characters.

Pokemon Black 2 cheat code works.

Fixes: #4570 
Fixes: #4625 