### PR TITLE
adds three controller profiles

### DIFF
--- a/OpenEmu/Controller-Database.plist
+++ b/OpenEmu/Controller-Database.plist
@@ -712,7 +712,7 @@
 				<key>OEControllerDeviceName</key>
 				<string>SteelSeries Stratus Duo via receiver</string>
 				<key>OEControllerVendorID</key>
-				<real>4152</real>
+				<integer>4152</integer>
 				<key>OEControllerProductID</key>
 				<integer>5168</integer>
 			</dict>
@@ -720,7 +720,7 @@
 				<key>OEControllerDeviceName</key>
 				<string>SteelSeries Stratus Duo via cable</string>
 				<key>OEControllerVendorID</key>
-				<real>4152</real>
+				<integer>4152</integer>
 				<key>OEControllerProductID</key>
 				<integer>5169</integer>
 			</dict>
@@ -3339,7 +3339,7 @@
 				<key>OEControllerDeviceName</key>
 				<string>Nintendo Switch Pro Controller</string>
 				<key>OEControllerVendorID</key>
-				<real>1406</real>
+				<integer>1406</integer>
 				<key>OEControllerProductID</key>
 				<integer>8201</integer>
 			</dict>
@@ -3924,7 +3924,7 @@
 				<key>OEControllerProductName</key>
 				<string>Retro Bit Bluetooth Controller</string>
 				<key>OEControllerVendorID</key>
-				<real>1118</real>
+				<integer>1118</integer>
 				<key>OEControllerProductID</key>
 				<integer>736</integer>
 				<key>OEControllerRequiresNameMatch</key>

--- a/OpenEmu/Controller-Database.plist
+++ b/OpenEmu/Controller-Database.plist
@@ -708,6 +708,22 @@
 				<key>OEControllerProductID</key>
 				<integer>4</integer>
 			</dict>
+			<dict>
+				<key>OEControllerDeviceName</key>
+				<string>SteelSeries Stratus Duo via receiver</string>
+				<key>OEControllerVendorID</key>
+				<real>4152</real>
+				<key>OEControllerProductID</key>
+				<integer>5168</integer>
+			</dict>
+			<dict>
+				<key>OEControllerDeviceName</key>
+				<string>SteelSeries Stratus Duo via cable</string>
+				<key>OEControllerVendorID</key>
+				<real>4152</real>
+				<key>OEControllerProductID</key>
+				<integer>5169</integer>
+			</dict>
 		</array>
 		<key>OEControllerMappings</key>
 		<dict>
@@ -3058,6 +3074,14 @@
 				<string>SteelSeries Nimbus</string>
 				<key>OEControllerVendorID</key>
 				<integer>273</integer>
+				<key>OEControllerProductID</key>
+				<integer>5152</integer>
+			</dict>
+			<dict>
+				<key>OEControllerDeviceName</key>
+				<string>SteelSeries Nimbus via cable</string>
+				<key>OEControllerVendorID</key>
+				<integer>4152</integer>
 				<key>OEControllerProductID</key>
 				<integer>5152</integer>
 			</dict>


### PR DESCRIPTION
Adds three controller profiles:

- MFi - SteelSeries Nimbus via cable
- Xinput - SteelSeries Stratus Duo via included 2.4 GHz USB receiver
- Xinput - SteelSeries Stratus Duo via micro USB cable

**Nimbus**: When plugged-in with a lightning-to-USB cable it switches off its Bluetooth connection and communicates by USB instead. It uses a different Vendor ID for this.

**Stratus Duo**: These two entries require the 360Controller kext extension. Until [updated controller information](https://github.com/360Controller/360Controller/pulls) is integrated into a future release of the extension someday, they'll also require a manually modified Info.plist within 360Controller.kext and a deactivation of kext-signing requirements.

PS: The Stratus Duo is also capable of Bluetooth, but its connection to macOS is so unstable as to render it useless.

PPS: Corrected a couple of values likely accidentally classified as floating-point ("real") when integer was intended. This sometimes happens when editing plists in Xcode. Probably an Xcode bug.