### PR TITLE
Fixed Controller Exit Transition in Key Mapping Screen

### DIFF
--- a/OpenEmu/PrefControlsController.swift
+++ b/OpenEmu/PrefControlsController.swift
@@ -380,6 +380,8 @@ final class PrefControlsController: NSViewController {
         outTransition.path = pathTransitionOut
         outTransition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
         outTransition.duration = 0.35
+        outTransition.fillMode = .forwards
+        outTransition.isRemovedOnCompletion = false
         
         // Setup animation that transitions the new controller image in
         let pathTransitionIn = CGMutablePath()
@@ -395,6 +397,8 @@ final class PrefControlsController: NSViewController {
         
         CATransaction.begin()
         CATransaction.setCompletionBlock {
+            self.controllerContainerView.setFrameOrigin(NSPoint(x: 0, y: 450))
+            
             if self.controllerView != nil {
                 self.controllerContainerView.replaceSubview(self.controllerView, with: newControllerView)
             } else {
@@ -408,7 +412,6 @@ final class PrefControlsController: NSViewController {
             }
         }
         
-        controllerContainerView.setFrameOrigin(NSPoint(x: 0, y: 450))
         if !reduceMotion {
             imageViewLayer?.add(outTransition, forKey: "animatePosition")
         }


### PR DESCRIPTION
## Current Issue
When switching consoles in the key mapping screen, the currently displayed controller abruptly disappears to make way for the new controller, which enters with a top-down transition. This behavior is visually unappealing.


https://github.com/OpenEmu/OpenEmu/assets/28265209/9848d16d-6e64-4e66-88f4-53e77eae23fe


## Proposed Solution
With this solution, the old controller, instead of disappearing, now exits by moving upward. This change makes the transition between controllers smoother and more visually pleasing.

https://github.com/OpenEmu/OpenEmu/assets/28265209/131c6715-dc2a-4f65-b206-b6c6a178875f

