### PR TITLE
Add Nintendo Switch Mega Drive/Genesis control pad to controller database

### DIFF
--- a/OpenEmu/Controller-Database.plist
+++ b/OpenEmu/Controller-Database.plist
@@ -3948,10 +3948,14 @@
 			<dict>
 				<key>OEControllerDeviceName</key>
 				<string>SNES Controller</string>
+				<key>OEControllerProductName</key>
+				<string>SNES Controller</string>
 				<key>OEControllerVendorID</key>
 				<integer>1406</integer>
 				<key>OEControllerProductID</key>
 				<integer>8215</integer>
+				<key>OEControllerRequiresNameMatch</key>
+				<true/>
 			</dict>
 		</array>
 		<key>OEControllerMappings</key>
@@ -4308,6 +4312,169 @@
 				<string>13</string>
 			</dict>
 			<key>OEControllerNintendoSwitchN64ControllerButtonCapture</key>
+			<dict>
+				<key>Name</key>
+				<string>Capture</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>14</string>
+			</dict>
+		</dict>
+	</dict>
+	<key>OEControllerNintendoSwitchMDGenControlPad</key>
+	<dict>
+		<key>OEControllerName</key>
+		<string>Nintendo Switch Online Sega Mega Drive/Genesis Control Pad</string>
+		<key>OEGenericControllerName</key>
+		<string>OEControllerNintendoSwitchMDGenControlPad</string>
+		<key>OEControllerDevices</key>
+		<array>
+			<dict>
+				<key>OEControllerDeviceName</key>
+				<string>Sega Mega Drive/Genesis Control Pad</string>
+				<key>OEControllerVendorID</key>
+				<integer>1406</integer>
+				<key>OEControllerProductID</key>
+				<integer>8222</integer>
+			</dict>
+			<dict>
+				<key>OEControllerDeviceName</key>
+				<string>Sega Mega Drive/Genesis Control Pad</string>
+				<key>OEControllerProductName</key>
+				<string>MD/Gen Control Pad</string>
+				<key>OEControllerVendorID</key>
+				<integer>1406</integer>
+				<key>OEControllerProductID</key>
+				<integer>8215</integer>
+				<key>OEControllerRequiresNameMatch</key>
+				<true/>
+			</dict>
+		</array>
+		<key>OEControllerMappings</key>
+		<dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadDPad</key>
+			<dict>
+				<key>Name</key>
+				<string>D-Pad</string>
+				<key>Type</key>
+				<string>HatSwitch</string>
+				<key>Usage</key>
+				<string>HatSwitch</string>
+				<key>Values</key>
+				<dict>
+					<key>OEControllerNintendoSwitchMDGenControlPadDPadUp</key>
+					<dict>
+						<key>Direction</key>
+						<string>N</string>
+						<key>Name</key>
+						<string>D-Pad Up</string>
+					</dict>
+					<key>OEControllerNintendoSwitchMDGenControlPadDPadDown</key>
+					<dict>
+						<key>Direction</key>
+						<string>S</string>
+						<key>Name</key>
+						<string>D-Pad Down</string>
+					</dict>
+					<key>OEControllerNintendoSwitchMDGenControlPadDPadLeft</key>
+					<dict>
+						<key>Direction</key>
+						<string>W</string>
+						<key>Name</key>
+						<string>D-Pad Left</string>
+					</dict>
+					<key>OEControllerNintendoSwitchMDGenControlPadDPadRight</key>
+					<dict>
+						<key>Direction</key>
+						<string>E</string>
+						<key>Name</key>
+						<string>D-Pad Right</string>
+					</dict>
+				</dict>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonA</key>
+			<dict>
+				<key>Name</key>
+				<string>A</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>2</string>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonB</key>
+			<dict>
+				<key>Name</key>
+				<string>B</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>1</string>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonC</key>
+			<dict>
+				<key>Name</key>
+				<string>C</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>6</string>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonX</key>
+			<dict>
+				<key>Name</key>
+				<string>X</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>7</string>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonY</key>
+			<dict>
+				<key>Name</key>
+				<string>Y</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>3</string>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonZ</key>
+			<dict>
+				<key>Name</key>
+				<string>Z</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>5</string>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonStart</key>
+			<dict>
+				<key>Name</key>
+				<string>Start</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>10</string>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonMode</key>
+			<dict>
+				<key>Name</key>
+				<string>Mode</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>8</string>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonHome</key>
+			<dict>
+				<key>Name</key>
+				<string>Home</string>
+				<key>Type</key>
+				<string>Button</string>
+				<key>Usage</key>
+				<string>13</string>
+			</dict>
+			<key>OEControllerNintendoSwitchMDGenControlPadButtonCapture</key>
 			<dict>
 				<key>Name</key>
 				<string>Capture</string>

--- a/OpenEmu/SystemPlugins/GameGear/Controller-Mappings.plist
+++ b/OpenEmu/SystemPlugins/GameGear/Controller-Mappings.plist
@@ -224,6 +224,17 @@
 		<key>OEGGButtonStart</key>
 		<string>OEControllerNintendoSwitchProControllerButtonPlus</string>
 	</dict>
+	<key>OEControllerNintendoSwitchMDGenControlPad</key>
+	<dict>
+		<key>OEGGButtonUp</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadDPadUp</string>
+		<key>OEGGButtonA</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonA</string>
+		<key>OEGGButtonB</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonB</string>
+		<key>OEGGButtonStart</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonStart</string>
+	</dict>
 	<key>OEControllerMicrosoftXboxOne</key>
 	<dict>
 		<key>OEGGButtonUp</key>

--- a/OpenEmu/SystemPlugins/Genesis/Controller-Mappings.plist
+++ b/OpenEmu/SystemPlugins/Genesis/Controller-Mappings.plist
@@ -378,6 +378,27 @@
 		<key>OEGenesisButtonMode</key>
 		<string>OEControllerNintendoSwitchProControllerButtonMinus</string>
 	</dict>
+	<key>OEControllerNintendoSwitchMDGenControlPad</key>
+	<dict>
+		<key>OEGenesisButtonUp</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadDPadUp</string>
+		<key>OEGenesisButtonA</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonA</string>
+		<key>OEGenesisButtonB</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonB</string>
+		<key>OEGenesisButtonC</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonC</string>
+		<key>OEGenesisButtonX</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonX</string>
+		<key>OEGenesisButtonY</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonY</string>
+		<key>OEGenesisButtonZ</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonZ</string>
+		<key>OEGenesisButtonStart</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonStart</string>
+		<key>OEGenesisButtonMode</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonMode</string>
+	</dict>
 	<key>OEControllerMicrosoftXboxOne</key>
 	<dict>
 		<key>OEGenesisButtonUp</key>

--- a/OpenEmu/SystemPlugins/SG-1000/Controller-Mappings.plist
+++ b/OpenEmu/SystemPlugins/SG-1000/Controller-Mappings.plist
@@ -224,6 +224,17 @@
 		<key>OESG1000ButtonPause</key>
 		<string>OEControllerNintendoSwitchProControllerButtonPlus</string>
 	</dict>
+	<key>OEControllerNintendoSwitchMDGenControlPad</key>
+	<dict>
+		<key>OESG1000ButtonUp</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadDPadUp</string>
+		<key>OESG1000Button1</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonA</string>
+		<key>OESG1000Button2</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonB</string>
+		<key>OESG1000ButtonPause</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonStart</string>
+	</dict>
 	<key>OEControllerMicrosoftXboxOne</key>
 	<dict>
 		<key>OESG1000ButtonUp</key>

--- a/OpenEmu/SystemPlugins/Sega 32X/Controller-Mappings.plist
+++ b/OpenEmu/SystemPlugins/Sega 32X/Controller-Mappings.plist
@@ -378,6 +378,27 @@
 		<key>OESega32XButtonMode</key>
 		<string>OEControllerNintendoSwitchProControllerButtonMinus</string>
 	</dict>
+	<key>OEControllerNintendoSwitchMDGenControlPad</key>
+	<dict>
+		<key>OESega32XButtonUp</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadDPadUp</string>
+		<key>OESega32XButtonA</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonA</string>
+		<key>OESega32XButtonB</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonB</string>
+		<key>OESega32XButtonC</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonC</string>
+		<key>OESega32XButtonX</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonX</string>
+		<key>OESega32XButtonY</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonY</string>
+		<key>OESega32XButtonZ</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonZ</string>
+		<key>OESega32XButtonStart</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonStart</string>
+		<key>OESega32XButtonMode</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonMode</string>
+	</dict>
 	<key>OEControllerMicrosoftXboxOne</key>
 	<dict>
 		<key>OESega32XButtonUp</key>

--- a/OpenEmu/SystemPlugins/Sega CD/Controller-Mappings.plist
+++ b/OpenEmu/SystemPlugins/Sega CD/Controller-Mappings.plist
@@ -378,6 +378,27 @@
 		<key>OESegaCDButtonMode</key>
 		<string>OEControllerNintendoSwitchProControllerButtonMinus</string>
 	</dict>
+	<key>OEControllerNintendoSwitchMDGenControlPad</key>
+	<dict>
+		<key>OESegaCDButtonUp</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadDPadUp</string>
+		<key>OESegaCDButtonA</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonA</string>
+		<key>OESegaCDButtonB</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonB</string>
+		<key>OESegaCDButtonC</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonC</string>
+		<key>OESegaCDButtonX</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonX</string>
+		<key>OESegaCDButtonY</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonY</string>
+		<key>OESegaCDButtonZ</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonZ</string>
+		<key>OESegaCDButtonStart</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonStart</string>
+		<key>OESegaCDButtonMode</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonMode</string>
+	</dict>
 	<key>OEControllerMicrosoftXboxOne</key>
 	<dict>
 		<key>OESegaCDButtonUp</key>

--- a/OpenEmu/SystemPlugins/SegaMasterSystem/Controller-Mappings.plist
+++ b/OpenEmu/SystemPlugins/SegaMasterSystem/Controller-Mappings.plist
@@ -224,6 +224,17 @@
 		<key>OESMSButtonStart</key>
 		<string>OEControllerNintendoSwitchProControllerButtonPlus</string>
 	</dict>
+	<key>OEControllerNintendoSwitchMDGenControlPad</key>
+	<dict>
+		<key>OESMSButtonUp</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadDPadUp</string>
+		<key>OESMSButtonA</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonA</string>
+		<key>OESMSButtonB</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonB</string>
+		<key>OESMSButtonStart</key>
+		<string>OEControllerNintendoSwitchMDGenControlPadButtonStart</string>
+	</dict>
 	<key>OEControllerMicrosoftXboxOne</key>
 	<dict>
 		<key>OESMSButtonUp</key>


### PR DESCRIPTION
Adds profile and automap configurations for the Nintendo Switch Online Sega Mega Drive/Genesis control pad (tested with the Japanese (6-button) variant). Automap works over Bluetooth or wired (USB-C).

A quirk with the controller is that it will broadcast with Vendor ID 1406 and Product ID 8215 (ie. as a Nintendo Switch Online SNES Controller) over Bluetooth, so additional matching for the controller name ("MD/Gen Control Pad") is included. (The matching for a NSO SNES Controller is updated to require a name match ("SNES Controller"), so that both controllers can be detected.)