### PR TITLE
Fix Project Building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ profile
 *.moved-aside
 DerivedData/
 CodeSign.xcconfig
+/OpenEmu.xcworkspace/xcshareddata/swiftpm/Package.resolved

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,9 +25,6 @@
 [submodule "SNES9x"]
 	path = SNES9x
 	url = ../../OpenEmu/SNES9x-Core.git
-[submodule "picodrive"]
-	path = picodrive
-	url = ../../OpenEmu/picodrive.git
 [submodule "VecXGL"]
 	path = VecXGL
 	url = ../../OpenEmu/VecXGL-Core.git
@@ -88,3 +85,6 @@
 [submodule "DeSmuME"]
 	path = DeSmuME
 	url = ../../OpenEmu/DeSmuME-Core.git
+[submodule "picodrive"]
+	path = picodrive
+	url = ../../OpenEmu/picodrive.git

--- a/OpenEmu.xcworkspace/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/OpenEmu.xcworkspace/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -32,8 +32,7 @@
                   continueAfterRunningActions = "No"
                   symbolName = "malloc_error_break"
                   moduleName = "libsystem_malloc.dylib"
-                  usesParentBreakpointCondition = "Yes"
-                  offsetFromSymbolStart = "0">
+                  usesParentBreakpointCondition = "Yes">
                </Location>
             </Locations>
          </BreakpointContent>

--- a/OpenEmu.xcworkspace/xcshareddata/xcschemes/OpenEmu + Cores.xcscheme
+++ b/OpenEmu.xcworkspace/xcshareddata/xcschemes/OpenEmu + Cores.xcscheme
@@ -91,11 +91,11 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "NO"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "82408A730FFDEB3F00F0FE7D"

--- a/OpenEmu.xcworkspace/xcshareddata/xcschemes/OpenEmu + Cores.xcscheme
+++ b/OpenEmu.xcworkspace/xcshareddata/xcschemes/OpenEmu + Cores.xcscheme
@@ -91,11 +91,11 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "82408A730FFDEB3F00F0FE7D"

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -7411,6 +7411,7 @@
 					"@loader_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.openemu.broker;
@@ -7444,6 +7445,7 @@
 					"@loader_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.openemu.broker;
@@ -7581,6 +7583,7 @@
 				INFOPLIST_PREPROCESS = NO;
 				INSTALL_PATH = "";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.openemu.OpenEmuHelperApp;
 				PRODUCT_NAME = OpenEmuHelperApp;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -7611,6 +7614,7 @@
 				INFOPLIST_PREPROCESS = NO;
 				INSTALL_PATH = "";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.openemu.OpenEmuHelperApp;
 				PRODUCT_NAME = OpenEmuHelperApp;
 				SWIFT_VERSION = 5.0;
@@ -8482,6 +8486,7 @@
 					"~/Library/Frameworks",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.$(PRODUCT_NAME:identifier)";
 				PRODUCT_NAME = OpenEmu;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
@@ -8518,6 +8523,7 @@
 					"~/Library/Frameworks",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.openemu.$(PRODUCT_NAME:identifier)";
 				PRODUCT_NAME = OpenEmu;
 				SWIFT_OBJC_BRIDGING_HEADER = "OpenEmu-Bridging-Header.h";

--- a/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
+++ b/OpenEmu/OpenEmu.xcodeproj/project.pbxproj
@@ -1945,7 +1945,6 @@
 		94A225D3170760D900098DA0 /* Keyboard-Mappings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Keyboard-Mappings.plist"; sourceTree = "<group>"; };
 		94A225DA170760FB00098DA0 /* OEFDSSystemResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEFDSSystemResponder.h; sourceTree = "<group>"; };
 		94A225DB170760FB00098DA0 /* OEFDSSystemResponder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEFDSSystemResponder.m; sourceTree = "<group>"; };
-		94A225DC170760FB00098DA0 /* OEFDSSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEFDSSystemResponderClient.h; sourceTree = "<group>"; };
 		94A225E01707610A00098DA0 /* Controller-Mappings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Mappings.plist"; sourceTree = "<group>"; };
 		94A225E11707610A00098DA0 /* Controller-Preferences.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Preferences.plist"; sourceTree = "<group>"; };
 		94A225E31707610A00098DA0 /* Keyboard-Mappings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Keyboard-Mappings.plist"; sourceTree = "<group>"; };
@@ -2037,7 +2036,6 @@
 		C6AF2859164E473C00681A06 /* Keyboard-Mappings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Keyboard-Mappings.plist"; sourceTree = "<group>"; };
 		C6AFE0D50FED6FDF00AC0CCF /* ControlsButtonSetupView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlsButtonSetupView.swift; sourceTree = "<group>"; };
 		C6B3E67B1365250D00D34947 /* OESMSSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OESMSSystemResponderClient.h; sourceTree = "<group>"; };
-		C6B3E691136525D100D34947 /* OENESSystemResponderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OENESSystemResponderClient.h; sourceTree = "<group>"; };
 		C6B947AF1364ECA600A425F0 /* GameBoy.oesystemplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GameBoy.oesystemplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6B947B31364ECA700A425F0 /* GameBoy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GameBoy-Info.plist"; sourceTree = "<group>"; };
 		C6B947BB1364EE6C00A425F0 /* OEGBSystemResponder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEGBSystemResponder.m; sourceTree = "<group>"; };
@@ -2052,6 +2050,8 @@
 		C6D120C417112E1300E868A8 /* OpenEmuSystem.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenEmuSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6F696BF1648F64B00B243DB /* Controller-Database.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Controller-Database.plist"; sourceTree = "<group>"; };
 		C6F697D5164E0EFD00B243DB /* Keyboard-Mappings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Keyboard-Mappings.plist"; sourceTree = "<group>"; };
+		DBFF44DC2E9D79C700B30F0A /* OENESSystemResponderClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OENESSystemResponderClient.h; sourceTree = "<group>"; };
+		DBFF44DD2E9D79D400B30F0A /* OEFDSSystemResponderClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OEFDSSystemResponderClient.h; sourceTree = "<group>"; };
 		EFBD5D7714EFE19A00FBD1E0 /* NSColor+OEAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSColor+OEAdditions.swift"; sourceTree = "<group>"; };
 		EFBD5D7B14EFE26300FBD1E0 /* OEGridView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEGridView.h; sourceTree = "<group>"; };
 		EFBD5D7C14EFE26300FBD1E0 /* OEGridView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEGridView.m; sourceTree = "<group>"; };
@@ -3971,7 +3971,7 @@
 			children = (
 				94A225DA170760FB00098DA0 /* OEFDSSystemResponder.h */,
 				94A225DB170760FB00098DA0 /* OEFDSSystemResponder.m */,
-				94A225DC170760FB00098DA0 /* OEFDSSystemResponderClient.h */,
+				DBFF44DD2E9D79D400B30F0A /* OEFDSSystemResponderClient.h */,
 				94A224C61707544C00098DA0 /* Supporting Files */,
 			);
 			path = "Nintendo FDS";
@@ -4201,7 +4201,7 @@
 				C64BB09D13647AEF00C1AB23 /* OENESSystemController.swift */,
 				C64BB09F13647B3500C1AB23 /* OENESSystemResponder.h */,
 				C64BB0A013647B3500C1AB23 /* OENESSystemResponder.m */,
-				C6B3E691136525D100D34947 /* OENESSystemResponderClient.h */,
+				DBFF44DC2E9D79C700B30F0A /* OENESSystemResponderClient.h */,
 				C64BB090136478E600C1AB23 /* Supporting Files */,
 			);
 			path = NES;
@@ -7403,6 +7403,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**";
 				INFOPLIST_FILE = broker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -7435,6 +7436,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**";
 				INFOPLIST_FILE = broker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -7574,6 +7576,7 @@
 					"$(inherited)",
 					"SUPPORTS_LIBRARY_REGISTRATION=0",
 				);
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**";
 				INFOPLIST_FILE = "OpenEmuHelperApp/OpenEmuHelperApp-Info.plist";
 				INFOPLIST_PREPROCESS = NO;
 				INSTALL_PATH = "";
@@ -7603,6 +7606,7 @@
 					"$(inherited)",
 					"SUPPORTS_LIBRARY_REGISTRATION=0",
 				);
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**";
 				INFOPLIST_FILE = "OpenEmuHelperApp/OpenEmuHelperApp-Info.plist";
 				INFOPLIST_PREPROCESS = NO;
 				INSTALL_PATH = "";
@@ -8469,6 +8473,7 @@
 					"SUPPORTS_LIBRARY_REGISTRATION=1",
 				);
 				GCC_WARN_UNUSED_LABEL = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**";
 				INFOPLIST_FILE = "OpenEmu-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -8504,6 +8509,7 @@
 					"SUPPORTS_LIBRARY_REGISTRATION=1",
 				);
 				GCC_WARN_UNUSED_LABEL = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate/**";
 				INFOPLIST_FILE = "OpenEmu-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
This PR fixes project building. Before this, the project would fail because of missing private headers. 

Since this project can now build, this also adds support for Apple Silicon (#5091). More work is needed to validate all emulators, but I am in the process of that. I have created working universal binaries, which can be uploaded as new versions of OpenEmu, once everything is validated.

Changes:
- Added a recursive header path (`$(SRCROOT)/../OpenEmuKit/Source/OpenEmuKitPrivate`), which finds the necessary private headers.
- Move picodrive to [290b39d](https://github.com/OpenEmu/picodrive/commit/290b39da6fa8cf932af6f65aac78506b24607159), which fixes the submodules for the repository.
- Move VecXGL to [bdeb8b1](https://github.com/OpenEmu/VecXGL-Core/commit/bdeb8b132245c5f1210187fc212d702cca0033da), which fixes an include error.

Other PRs:
- [evands:fix-xcode-164-compile](https://github.com/OpenEmu/OpenEmu-SDK/pull/31/commits/a594e08b3fed9eefc8e13745164d65b8ae530b01)
- [ActuallyTaylor:fix-uint8-casting](https://github.com/OpenEmu/Nestopia-Core/pull/9)