### PR TITLE
Fix automap and mapping issue with Nintendo Switch N64 controller

### DIFF
--- a/OpenEmu/SystemPlugins/N64/Controller-Mappings.plist
+++ b/OpenEmu/SystemPlugins/N64/Controller-Mappings.plist
@@ -390,13 +390,13 @@
 		<key>OEN64AnalogLeft</key>
 		<string>OEControllerNintendoSwitchN64ControllerAnalogLeft</string>
 		<key>OEN64ButtonCUp</key>
-		<string>OEControllerNintendoSwitchN64ControllerCUp</string>
+		<string>OEControllerNintendoSwitchN64ControllerButtonCUp</string>
 		<key>OEN64ButtonCDown</key>
-		<string>OEControllerNintendoSwitchN64ControllerCDown</string>
+		<string>OEControllerNintendoSwitchN64ControllerButtonCDown</string>
 		<key>OEN64ButtonCLeft</key>
-		<string>OEControllerNintendoSwitchN64ControllerCLeft</string>
+		<string>OEControllerNintendoSwitchN64ControllerButtonCLeft</string>
 		<key>OEN64ButtonCRight</key>
-		<string>OEControllerNintendoSwitchN64ControllerCRight</string>
+		<string>OEControllerNintendoSwitchN64ControllerButtonCRight</string>
 		<key>OEN64ButtonA</key>
 		<string>OEControllerNintendoSwitchN64ControllerButtonA</string>
 		<key>OEN64ButtonB</key>

--- a/OpenEmu/SystemPlugins/Virtual Boy/Controller-Mappings.plist
+++ b/OpenEmu/SystemPlugins/Virtual Boy/Controller-Mappings.plist
@@ -342,13 +342,13 @@
 		<key>OEVBButtonLeftUp</key>
 		<string>OEControllerNintendoSwitchN64ControllerDPadUp</string>
 		<key>OEVBButtonRightUp</key>
-		<string>OEControllerNintendoSwitchN64ControllerCRight</string>
+		<string>OEControllerNintendoSwitchN64ControllerButtonCUp</string>
 		<key>OEVBButtonRightDown</key>
-		<string>OEControllerNintendoSwitchN64ControllerCDown</string>
+		<string>OEControllerNintendoSwitchN64ControllerButtonCDown</string>
 		<key>OEVBButtonRightLeft</key>
-		<string>OEControllerNintendoSwitchN64ControllerCLeft</string>
+		<string>OEControllerNintendoSwitchN64ControllerButtonCLeft</string>
 		<key>OEVBButtonRightRight</key>
-		<string>OEControllerNintendoSwitchN64ControllerCRight</string>
+		<string>OEControllerNintendoSwitchN64ControllerButtonCRight</string>
 		<key>OEVBButtonA</key>
 		<string>OEControllerNintendoSwitchN64ControllerButtonA</string>
 		<key>OEVBButtonB</key>


### PR DESCRIPTION
Fixes the automap configurations of the Nintendo Switch N64 controller for N64/Virtual Boy (#4611).

Also fixes an issue in Settings > Controls where a controller sending input without a corresponding null state (eg: the Switch N64 controller) causes the UI to ignore further input (#4611, #5033). The fix is for the UI to ignore unrecognised input (ie. input that doesn't map to the expected device mappings), and log the event (using NSLog).