### PR TITLE
Fix support for regional variant languages

### DIFF
--- a/OpenEmu/AppDelegate.swift
+++ b/OpenEmu/AppDelegate.swift
@@ -459,13 +459,13 @@ class AppDelegate: NSObject {
         }
         #endif
         let alert = OEAlert()
-        alert.messageText = NSLocalizedString("ALERT_INPUT_MONITORING_HEADLINE", comment:"Headline for Input Monitoring permissions")
-        var informativeText = NSLocalizedString("ALERT_INPUT_MONITORING_PART1", comment:"Message for Input Monitoring permissions")
+        alert.messageText = Bundle.main.preferredLocalizedString(forKey: "ALERT_INPUT_MONITORING_HEADLINE", value: "No translation", table: nil) // Headline for Input Monitoring permissions
+        var informativeText = Bundle.main.preferredLocalizedString(forKey: "ALERT_INPUT_MONITORING_PART1", value: "No translation", table: nil) // Message for Input Monitoring permissions
         informativeText += "\n\n"
         if #available(macOS 12.0, *) {
-            informativeText += NSLocalizedString("ALERT_INPUT_MONITORING_PART2_MONTEREY", comment:"Message for Input Monitoring permissions")
+            informativeText += Bundle.main.preferredLocalizedString(forKey: "ALERT_INPUT_MONITORING_PART2_MONTEREY", value: "No translation", table: nil) // Message for Input Monitoring permissions
         } else {
-            informativeText += NSLocalizedString("ALERT_INPUT_MONITORING_PART2", comment:"Message for Input Monitoring permissions")
+            informativeText += Bundle.main.preferredLocalizedString(forKey: "ALERT_INPUT_MONITORING_PART2", value: "No translation", table: nil) // Message for Input Monitoring permissions
         }
         alert.informativeText = informativeText
         alert.defaultButtonTitle = NSLocalizedString("Open System Preferences", comment:"")

--- a/OpenEmu/AppMover.swift
+++ b/OpenEmu/AppMover.swift
@@ -73,12 +73,12 @@ public enum AppMover {
         }
         
         let alert = NSAlert()
-        alert.messageText = NSLocalizedString("MOVE_ALERT_TITLE", value: "Move to Applications folder", comment: "")
-        alert.informativeText = NSLocalizedString("MOVE_ALERT_INFO_TEXT", value: "OpenEmu must move to your Applications folder in order to work properly.", comment: "")
+        alert.messageText = bundle.preferredLocalizedString(forKey: "MOVE_ALERT_TITLE", value: "No translation", table: nil)
+        alert.informativeText = bundle.preferredLocalizedString(forKey: "MOVE_ALERT_INFO_TEXT", value: "No translation", table: nil)
         if needAuth {
-            alert.informativeText.append(" " + NSLocalizedString("MOVE_ALERT_NEEDS_AUTH", value: "You need to authenticate with an administrator name and password to complete this step.", comment: ""))
+            alert.informativeText.append(" " + bundle.preferredLocalizedString(forKey: "MOVE_ALERT_NEEDS_AUTH", value: "No translation", table: nil))
         }
-        alert.addButton(withTitle: NSLocalizedString("MOVE_ALERT_MOVE_BUTTON", value: "Move to Applications Folder", comment: ""))
+        alert.addButton(withTitle: bundle.preferredLocalizedString(forKey: "MOVE_ALERT_MOVE_BUTTON", value: "No translation", table: nil))
         alert.addButton(withTitle: NSLocalizedString("Quit", comment: ""))
         if needAuth {
             alert.addButton(withTitle: NSLocalizedString("Choose Location…", value: "Choose Location…", comment: ""))

--- a/OpenEmu/BlankSlateView.swift
+++ b/OpenEmu/BlankSlateView.swift
@@ -284,7 +284,7 @@ class BlankSlateView: NSView {
             
             headline = NSLocalizedString("Collections", comment: "")
             // TODO: Use a different wording for smart collections, as games cannot be added manually.
-            informationalText = .localizedStringWithFormat(NSLocalizedString("Create a personal game selection. To add to a collection, select a game from your console library and drag it to ’%@’ in the sidebar.", comment: ""), collection.collectionViewName)
+            informationalText = .localizedStringWithFormat(Bundle.main.preferredLocalizedString(forKey: "Create a personal game selection. To add to a collection, select a game from your console library and drag it to ’%@’ in the sidebar.", value: "No translation", table: nil), collection.collectionViewName)
         }
         else if representedObject is OEDBSaveStatesMedia {
             

--- a/OpenEmu/ControlsButtonSetupView.swift
+++ b/OpenEmu/ControlsButtonSetupView.swift
@@ -405,7 +405,7 @@ private class ControlsSetupViewParser {
         
         var i = 0
         while i < controlList.count {
-            let sectionTitle = NSLocalizedString(controlList[i] as? String ?? "", tableName: "ControlLabels", comment: "Section Title")
+            let sectionTitle = Bundle.main.preferredLocalizedString(forKey: controlList[i] as? String ?? "", value: "No translation", table: "ControlLabels") // Section Title
             let sectionContents = controlList[i + 1] as? [[AnyHashable]] ?? []
             for group in sectionContents {
                 addGroup()
@@ -416,12 +416,12 @@ private class ControlsSetupViewParser {
                         if row == "-" {
                             addRowSeperator()
                         } else {
-                            addGroupLabel(NSLocalizedString(row, tableName: "ControlLabels", comment: "Group Label"))
+                            addGroupLabel(Bundle.main.preferredLocalizedString(forKey: row, value: "No translation", table: "ControlLabels")) // Group Label
                         }
                     }
                     else if let row = row as? [String: String] {
                         
-                        let label = NSLocalizedString(row[OEControlListKeyLabelKey] ?? "", tableName: "ControlLabels", comment: "Button Label")
+                        let label = Bundle.main.preferredLocalizedString(forKey: row[OEControlListKeyLabelKey] ?? "", value: "No translation", table: "ControlLabels") // Button Label
                         
                         addButton(name: row[OEControlListKeyNameKey] ?? "",
                                   label: label + ":")

--- a/OpenEmu/CoreUpdater.swift
+++ b/OpenEmu/CoreUpdater.swift
@@ -272,7 +272,7 @@ final class CoreUpdater: NSObject {
             }
             
             let coreName = download.name
-            let message = String(format: NSLocalizedString("OpenEmu uses 'Cores' to emulate games. You need the %@ Core to play %@", comment: ""), coreName, game.displayName)
+            let message = String(format: Bundle.main.preferredLocalizedString(forKey: "OpenEmu uses 'Cores' to emulate games. You need the %@ Core to play %@", value: "No translation", table: nil), coreName, game.displayName)
             installCore(with: download, message: message, completionHandler: handler)
         }
         else {
@@ -285,7 +285,7 @@ final class CoreUpdater: NSObject {
         let coreID = state.coreIdentifier.lowercased()
         if let download = coresDict[coreID] {
             let coreName = download.name
-            let message = String(format: NSLocalizedString("To launch the save state %@ you will need to install the '%@' Core", comment: ""), state.displayName, coreName)
+            let message = String(format: Bundle.main.preferredLocalizedString(forKey: "To launch the save state %@ you will need to install the '%@' Core", value: "No translation", table: nil), state.displayName, coreName)
             installCore(with: download, message: message, completionHandler: handler)
         } else {
             // TODO: create proper error saying that no core is available for the state

--- a/OpenEmu/GameControlsBar.swift
+++ b/OpenEmu/GameControlsBar.swift
@@ -346,7 +346,7 @@ final class GameControlsBar: NSWindow {
         // cheats
         if gameViewController.supportsCheats {
             item = NSMenuItem()
-            item.title = NSLocalizedString("Select Cheat", comment: "")
+            item.title = Bundle.main.preferredLocalizedString(forKey: "Select Cheat", value: "No translation", table: nil)
             item.submenu = cheatsMenu
             menu.addItem(item)
         }
@@ -354,7 +354,7 @@ final class GameControlsBar: NSWindow {
         // core selection
         if let coresMenu = coresMenu {
             item = NSMenuItem()
-            item.title = NSLocalizedString("Select Core", comment: "")
+            item.title = Bundle.main.preferredLocalizedString(forKey: "Select Core", value: "No translation", table: nil)
             item.submenu = coresMenu
             menu.addItem(item)
         }
@@ -363,7 +363,7 @@ final class GameControlsBar: NSWindow {
         if gameViewController.supportsMultipleDiscs {
             let maxDiscs = gameViewController.document.discCount
             item = NSMenuItem()
-            item.title = NSLocalizedString("Select Disc", comment: "")
+            item.title = Bundle.main.preferredLocalizedString(forKey: "Select Disc", value: "No translation", table: nil)
             item.submenu = maxDiscs > 1 ? discsMenu : nil
             item.isEnabled = maxDiscs > 1 ? true : false
             menu.addItem(item)
@@ -373,20 +373,20 @@ final class GameControlsBar: NSWindow {
         if gameViewController.supportsDisplayModeChange,
            !gameViewController.document.displayModes.isEmpty {
             item = NSMenuItem()
-            item.title = NSLocalizedString("Select Display Mode", comment: "")
+            item.title = Bundle.main.preferredLocalizedString(forKey: "Select Display Mode", value: "No translation", table: nil)
             item.submenu = displayModesMenu
             menu.addItem(item)
         }
         
         // video shader
         item = NSMenuItem()
-        item.title = NSLocalizedString("Select Shader", comment: "")
+        item.title = Bundle.main.preferredLocalizedString(forKey: "Select Shader", value: "No translation", table: nil)
         item.submenu = shadersMenu
         menu.addItem(item)
         
         // integral scaling
         item = NSMenuItem()
-        item.title = NSLocalizedString("Select Scale", comment: "")
+        item.title = Bundle.main.preferredLocalizedString(forKey: "Select Scale", value: "No translation", table: nil)
         if let scaleMenu = scaleMenu {
             item.submenu = scaleMenu
         } else {
@@ -397,7 +397,7 @@ final class GameControlsBar: NSWindow {
         // audio output
         if UserDefaults.standard.bool(forKey: Self.showsAudioOutputKey) {
             item = NSMenuItem()
-            item.title = NSLocalizedString("Select Audio Output Device", comment: "")
+            item.title = Bundle.main.preferredLocalizedString(forKey: "Select Audio Output Device", value: "No translation", table: nil)
             if let audioOutputMenu = audioOutputMenu {
                 item.submenu = audioOutputMenu
             } else {

--- a/OpenEmu/GameScannerViewController.swift
+++ b/OpenEmu/GameScannerViewController.swift
@@ -220,7 +220,7 @@ final class GameScannerViewController: NSViewController {
                 if isScanningDirectory {
                     status = NSLocalizedString("Scanning Directory", comment: "")
                 } else {
-                    status = String(format: NSLocalizedString("Game %ld of %ld", comment: ""), count, maxItems)
+                    status = String(format: Bundle.main.preferredLocalizedString(forKey: "Game %ld of %ld", value: "No translation", table: nil), count, maxItems)
                 }
                 
                 togglePauseButton.isEnabled = true
@@ -578,13 +578,15 @@ extension GameScannerViewController: ROMImporterDelegate {
                 if itemsAlreadyInDatabase == nil {
                     itemsAlreadyInDatabase = NSLocalizedString("Already in library:", comment:"")
                 }
-                itemsAlreadyInDatabase! += "\n• " + String(format: NSLocalizedString("\"%@\" in %@", comment:"Import error description: file already imported (first item: filename, second item: system library name)"), failedFilename, failedItem.romLocation!)
+                itemsAlreadyInDatabase! += "\n• " + String(format: Bundle.main.preferredLocalizedString(forKey: "\"%@\" in %@", value: "No translation", table: nil), // Import error description: file already imported (first item: filename, second item: system library name)
+                                                           failedFilename, failedItem.romLocation!)
 
             } else if error.domain == OEImportErrorDomainFatal && error.code == OEImportErrorCode.alreadyInDatabaseFileUnreachable.rawValue {
                 if itemsAlreadyInDatabaseFileUnreachable == nil {
                     itemsAlreadyInDatabaseFileUnreachable = NSLocalizedString("Already in library, but manually deleted or unreachable:", comment:"")
                 }
-                itemsAlreadyInDatabaseFileUnreachable! += "\n• " + String(format: NSLocalizedString("\"%@\" in %@", comment:"Import error description: file already imported (first item: filename, second item: system library name)"), failedFilename, failedItem.romLocation!)
+                itemsAlreadyInDatabaseFileUnreachable! += "\n• " + String(format: Bundle.main.preferredLocalizedString(forKey: "\"%@\" in %@", value: "No translation", table: nil), // Import error description: file already imported (first item: filename, second item: system library name)
+                                                                          failedFilename, failedItem.romLocation!)
 
             } else if error.domain == OEImportErrorDomainFatal && error.code == OEImportErrorCode.noSystem.rawValue {
                 if itemsNoSystem == nil {

--- a/OpenEmu/LibraryToolbarDelegate.swift
+++ b/OpenEmu/LibraryToolbarDelegate.swift
@@ -150,18 +150,18 @@ final class LibraryToolbarDelegate: NSObject, NSToolbarDelegate {
     private lazy var viewModeMenu: NSMenuItem = {
         
         let gridView = NSMenuItem()
-        gridView.title = NSLocalizedString("as Grid", tableName: "MainMenu", comment: "")
+        gridView.title = Bundle.main.preferredLocalizedString(forKey: "as Grid", value: "No translation", table: "MainMenu")
         gridView.action = #selector(LibraryController.switchToGridView(_:))
         
         let listView = NSMenuItem()
-        listView.title = NSLocalizedString("as List", tableName: "MainMenu", comment: "")
+        listView.title = Bundle.main.preferredLocalizedString(forKey: "as List", value: "No translation", table: "MainMenu")
         listView.action = #selector(LibraryController.switchToListView(_:))
         
         let menu = NSMenu()
         menu.items = [gridView, listView]
         
         let viewModeMenu = NSMenuItem()
-        viewModeMenu.title = NSLocalizedString("View", tableName: "MainMenu", comment:"")
+        viewModeMenu.title = Bundle.main.preferredLocalizedString(forKey: "View", value: "No translation", table: "MainMenu")
         viewModeMenu.submenu = menu
         
         return viewModeMenu
@@ -171,10 +171,10 @@ final class LibraryToolbarDelegate: NSObject, NSToolbarDelegate {
     
     private(set) lazy var categoryToolbarItem: NSToolbarItem = {
         
-        let titles = [NSLocalizedString("Toolbar: Library", value: "Library", comment: "toolbar, category label"),
-                      NSLocalizedString("Toolbar: Save States", value: "Save States", comment: "toolbar, category label"),
-                      NSLocalizedString("Toolbar: Screenshots", value: "Screenshots", comment: "toolbar, category label"),
-                      NSLocalizedString("Toolbar: Homebrew", value: "Homebrew", comment: "toolbar, category label")]
+        let titles = [Bundle.main.preferredLocalizedString(forKey: "Toolbar: Library", value: "No translation", table: nil), // toolbar, category label
+                      Bundle.main.preferredLocalizedString(forKey: "Toolbar: Save States", value: "No translation", table: nil), // toolbar, category label
+                      Bundle.main.preferredLocalizedString(forKey: "Toolbar: Screenshots", value: "No translation", table: nil), // toolbar, category label
+                      Bundle.main.preferredLocalizedString(forKey: "Toolbar: Homebrew", value: "No translation", table: nil)] // toolbar, category label
         
         let segmControl = NSSegmentedControl(labels: titles, trackingMode: .selectOne, target: toolbarOwner, action: #selector(LibraryController.switchCategory(_:)))
         
@@ -190,22 +190,22 @@ final class LibraryToolbarDelegate: NSObject, NSToolbarDelegate {
     private lazy var categoryMenu: NSMenuItem = {
         
         let library = NSMenuItem()
-        library.title = NSLocalizedString("Toolbar: Library", value: "Library", comment: "")
+        library.title = Bundle.main.preferredLocalizedString(forKey: "Toolbar: Library", value: "No translation", table: nil)
         library.tag = 100
         library.action = #selector(LibraryController.switchCategoryFromMenu(_:))
         
         let savesStates = NSMenuItem()
-        savesStates.title = NSLocalizedString("Toolbar: Save States", value: "Save States", comment: "")
+        savesStates.title = Bundle.main.preferredLocalizedString(forKey: "Toolbar: Save States", value: "No translation", table: nil)
         savesStates.tag = 101
         savesStates.action = #selector(LibraryController.switchCategoryFromMenu(_:))
         
         let screenshots = NSMenuItem()
-        screenshots.title = NSLocalizedString("Toolbar: Screenshots", value: "Screenshots", comment: "")
+        screenshots.title = Bundle.main.preferredLocalizedString(forKey: "Toolbar: Screenshots", value: "No translation", table: nil)
         screenshots.tag = 102
         screenshots.action = #selector(LibraryController.switchCategoryFromMenu(_:))
         
         let homebrew = NSMenuItem()
-        homebrew.title = NSLocalizedString("Toolbar: Homebrew", value: "Homebrew", comment: "")
+        homebrew.title = Bundle.main.preferredLocalizedString(forKey: "Toolbar: Homebrew", value: "No translation", table: nil)
         homebrew.tag = 103
         homebrew.action = #selector(LibraryController.switchCategoryFromMenu(_:))
         

--- a/OpenEmu/MainWindowController.swift
+++ b/OpenEmu/MainWindowController.swift
@@ -268,7 +268,7 @@ extension MainWindowController: LibraryControllerDelegate {
                     game.status = .alert
                     game.save()
                     
-                    let messageText = String(format: NSLocalizedString("The game '%@' could not be started because a rom file could not be found. Do you want to locate it?", comment: ""), game.name)
+                    let messageText = String(format: Bundle.main.preferredLocalizedString(forKey: "The game '%@' could not be started because a rom file could not be found. Do you want to locate it?", value: "No translation", table: nil), game.name)
                     let alert = OEAlert()
                     alert.messageText = messageText
                     alert.defaultButtonTitle = NSLocalizedString("Locate…", comment: "")
@@ -278,7 +278,7 @@ extension MainWindowController: LibraryControllerDelegate {
                         let originalURL = missingRom?.url
                         let fileType = originalURL?.pathExtension
                         
-                        let panelTitle = String(format: NSLocalizedString("Locate '%@'", comment: "Locate panel title"), originalURL?.pathComponents.last ?? "")
+                        let panelTitle = String(format: Bundle.main.preferredLocalizedString(forKey: "Locate '%@'", value: "No translation", table: nil), originalURL?.pathComponents.last ?? "") // Locate panel title
                         let panel = NSOpenPanel()
                         panel.message = panelTitle
                         panel.canChooseDirectories = false
@@ -336,11 +336,9 @@ extension MainWindowController: LibraryControllerDelegate {
                     } else {
                         alert.messageText = String(format: NSLocalizedString("The %@ core has quit unexpectedly", comment: ""), coreName)
                         if glitchy {
-                            alert.informativeText = String(format: NSLocalizedString("The %@ core has compatibility issues and some games may contain glitches or not play at all.\n\nPlease do not report problems as we are not responsible for the development of %@.", comment: ""), coreName, coreName)
+                            alert.informativeText = String(format: Bundle.main.preferredLocalizedString(forKey: "The %@ core has compatibility issues and some games may contain glitches or not play at all.\n\nPlease do not report problems as we are not responsible for the development of %@.", value: "No translation", table: nil), coreName, coreName)
                         } else {
-                            alert.informativeText = NSLocalizedString("ALERT_CORE_GLITCHES_FEEDBACK_HTML",
-                                comment: "Suggestion for crashed cores (HTML). Localizers: specify the report must be written in English"
-                            )
+                            alert.informativeText = Bundle.main.preferredLocalizedString(forKey: "ALERT_CORE_GLITCHES_FEEDBACK_HTML", value: "No translation", table: nil) // Suggestion for crashed cores (HTML). Localizers: specify the report must be written in English
                             alert.messageUsesHTML = true
                         }
                         alert.defaultButtonTitle = NSLocalizedString("OK", comment: "")

--- a/OpenEmu/OEAlert+Additions.swift
+++ b/OpenEmu/OEAlert+Additions.swift
@@ -91,7 +91,7 @@ extension OEAlert {
     final class func deleteSaveState(name: String) -> OEAlert {
         
         let alert = OEAlert()
-        alert.messageText = .localizedStringWithFormat(NSLocalizedString("Are you sure you want to delete the save state called '%@' from your OpenEmu library?", comment: ""), name)
+        alert.messageText = .localizedStringWithFormat(Bundle.main.preferredLocalizedString(forKey: "Are you sure you want to delete the save state called '%@' from your OpenEmu library?", value: "No translation", table: nil), name)
         alert.defaultButtonTitle = NSLocalizedString("Delete Save State", comment: "")
         alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
         alert.showSuppressionButton(forUDKey: OEDeleteSaveStateAlertSuppressionKey)
@@ -115,7 +115,7 @@ extension OEAlert {
     final class func deleteScreenshot(name: String) -> OEAlert {
         
         let alert = OEAlert()
-        alert.messageText = .localizedStringWithFormat(NSLocalizedString("Are you sure you want to delete the screenshot called '%@' from your OpenEmu library?", comment: ""), name)
+        alert.messageText = .localizedStringWithFormat(Bundle.main.preferredLocalizedString(forKey: "Are you sure you want to delete the screenshot called '%@' from your OpenEmu library?", value: "No translation", table: nil), name)
         alert.defaultButtonTitle = NSLocalizedString("Delete Screenshot", comment: "")
         alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
         alert.showSuppressionButton(forUDKey: OEDeleteScreenshotAlertSuppressionKey)
@@ -126,7 +126,7 @@ extension OEAlert {
     final class func deleteShaderPreset(name: String) -> OEAlert {
         
         let alert = OEAlert()
-        alert.messageText = .localizedStringWithFormat(NSLocalizedString("Are you sure you want to delete the shader preset called '%@'?", comment: ""), name)
+        alert.messageText = .localizedStringWithFormat(Bundle.main.preferredLocalizedString(forKey: "Are you sure you want to delete the shader preset called '%@'?", value: "No translation", table: nil), name)
         alert.defaultButtonTitle = NSLocalizedString("Delete Shader Preset", comment: "")
         alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
         alert.showSuppressionButton(forUDKey: OEDeleteShaderPresetAlertSuppressionKey)
@@ -173,7 +173,7 @@ extension OEAlert {
     final class func removeCollection(name: String) -> OEAlert {
         
         let alert = OEAlert()
-        alert.messageText = .localizedStringWithFormat(NSLocalizedString("Are you sure you want to remove the collection '%@'?", comment: ""), name)
+        alert.messageText = .localizedStringWithFormat(Bundle.main.preferredLocalizedString(forKey: "Are you sure you want to remove the collection '%@'?", value: "No translation", table: nil), name)
         alert.defaultButtonTitle = NSLocalizedString("Remove Collection", comment: "")
         alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
         alert.showSuppressionButton(forUDKey: OERemoveCollectionAlertSuppressionKey)

--- a/OpenEmu/OEGameDocument.swift
+++ b/OpenEmu/OEGameDocument.swift
@@ -481,7 +481,7 @@ final class OEGameDocument: NSDocument {
                 }
                 
                 let fileName = (url.lastPathComponent as NSString).deletingPathExtension
-                let informativeText = String(format: NSLocalizedString("The game '%@' was imported.", comment: ""), fileName)
+                let informativeText = String(format: Bundle.main.preferredLocalizedString(forKey: "The game '%@' was imported.", value: "No translation", table: nil), fileName)
                 
                 let alert = OEAlert()
                 alert.messageText = NSLocalizedString("Your game finished importing, do you want to play it now?", comment: "")
@@ -757,7 +757,7 @@ final class OEGameDocument: NSDocument {
         
         if corePlugin.hasGlitches(forSystemIdentifier: systemPlugin.systemIdentifier) && showAlert {
             
-            let message = String(format: NSLocalizedString("The %@ core has compatibility issues and some games may contain glitches or not play at all.\n\nPlease do not report problems as we are not responsible for the development of %@.", comment: ""), coreName, coreName)
+            let message = String(format: Bundle.main.preferredLocalizedString(forKey: "The %@ core has compatibility issues and some games may contain glitches or not play at all.\n\nPlease do not report problems as we are not responsible for the development of %@.", value: "No translation", table: nil), coreName, coreName)
             let alert = OEAlert()
             alert.messageText = NSLocalizedString("Warning", comment: "")
             alert.informativeText = message
@@ -937,7 +937,8 @@ final class OEGameDocument: NSDocument {
         isEmulationPaused = true
         
         let devHandler = notification.object as? OEDeviceHandler
-        let message = String(format: NSLocalizedString("The battery in device number %lu, %@, is low. Please charge or replace the battery.", comment: "Low battery alert detail message."), devHandler?.deviceNumber ?? 0, devHandler?.deviceDescription?.name ?? "")
+        let message = String(format: Bundle.main.preferredLocalizedString(forKey: "The battery in device number %lu, %@, is low. Please charge or replace the battery.", value: "No translation", table: nil), // Low battery alert detail message
+                             devHandler?.deviceNumber ?? 0, devHandler?.deviceDescription?.name ?? "")
         let alert = OEAlert()
         alert.messageText = NSLocalizedString("Low Controller Battery", comment: "Device battery level is low.")
         alert.informativeText = message
@@ -954,7 +955,7 @@ final class OEGameDocument: NSDocument {
         isEmulationPaused = true
         
         let devHandler = notification.userInfo?[OEDeviceManagerDeviceHandlerUserInfoKey] as? OEDeviceHandler
-        let message = String(format: NSLocalizedString("Device number %lu, %@, has disconnected.", comment: "Device disconnection detail message."), devHandler?.deviceNumber ?? 0, devHandler?.deviceDescription?.name ?? "")
+        let message = String(format: Bundle.main.preferredLocalizedString(forKey: "Device number %lu, %@, has disconnected.", value: "No translation", table: nil), devHandler?.deviceNumber ?? 0, devHandler?.deviceDescription?.name ?? "") // Device disconnection detail message.
         let alert = OEAlert()
         alert.messageText = NSLocalizedString("Device Disconnected", comment: "A controller device has disconnected.")
         alert.informativeText = message
@@ -1279,7 +1280,7 @@ final class OEGameDocument: NSDocument {
         
         alert.inputLabelText = NSLocalizedString("Code:", comment: "")
         alert.showsInputField = true
-        alert.inputPlaceholderText = NSLocalizedString("Join multi-line cheats with '+' e.g. 000-000+111-111", comment: "")
+        alert.inputPlaceholderText = Bundle.main.preferredLocalizedString(forKey: "Join multi-line cheats with '+' e.g. 000-000+111-111", value: "No translation", table: nil)
         
         alert.defaultButtonTitle = NSLocalizedString("Add Cheat", comment: "")
         alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")

--- a/OpenEmu/OEGameLayerNotificationView.swift
+++ b/OpenEmu/OEGameLayerNotificationView.swift
@@ -69,35 +69,35 @@ final class OEGameLayerNotificationView: NSImageView {
     @objc public func showFastForward(enabled: Bool) {
         performNotification(img: fastForwardImage, enabled: enabled, state: &isFastForwarding)
         if enabled {
-            postAccessibilityNotification(announcement: NSLocalizedString("Fast Forward", tableName: "ControlLabels", comment: ""))
+            postAccessibilityNotification(announcement: Bundle.main.preferredLocalizedString(forKey: "Fast Forward", value: "No translation", table: "ControlLabels"))
         }
     }
     
     @objc public func showRewind(enabled: Bool) {
         performNotification(img: rewindImage, enabled: enabled, state: &isRewinding)
         if enabled {
-            postAccessibilityNotification(announcement: NSLocalizedString("Rewind", tableName: "ControlLabels", comment: ""))
+            postAccessibilityNotification(announcement: Bundle.main.preferredLocalizedString(forKey: "Rewind", value: "No translation", table: "ControlLabels"))
         }
     }
     
     @objc public func showQuickSave() {
         performShowHideNotification(img: quicksaveImage)
-        postAccessibilityNotification(announcement: NSLocalizedString("Quick Save", tableName: "ControlLabels", comment: ""))
+        postAccessibilityNotification(announcement: Bundle.main.preferredLocalizedString(forKey: "Quick Save", value: "No translation", table: "ControlLabels"))
     }
     
     @objc public func showScreenShot() {
         performShowHideNotification(img: screenshotImage)
-        postAccessibilityNotification(announcement: NSLocalizedString("Screenshot", tableName: "ControlLabels", comment: ""))
+        postAccessibilityNotification(announcement: Bundle.main.preferredLocalizedString(forKey: "Screenshot", value: "No translation", table: "ControlLabels"))
     }
     
     @objc public func showStepForward() {
         performShowHideNotification(img: stepForwardImage)
-        postAccessibilityNotification(announcement: NSLocalizedString("Step Forward", tableName: "ControlLabels", comment: ""))
+        postAccessibilityNotification(announcement: Bundle.main.preferredLocalizedString(forKey: "Step Forward", value: "No translation", table: "ControlLabels"))
     }
     
     @objc public func showStepBackward() {
         performShowHideNotification(img: stepBackwardImage)
-        postAccessibilityNotification(announcement: NSLocalizedString("Step Backward", tableName: "ControlLabels", comment: ""))
+        postAccessibilityNotification(announcement: Bundle.main.preferredLocalizedString(forKey: "Step Backward", value: "No translation", table: "ControlLabels"))
     }
     
     // MARK: - Animation

--- a/OpenEmu/OELibraryDatabase+Maintenance.swift
+++ b/OpenEmu/OELibraryDatabase+Maintenance.swift
@@ -202,7 +202,7 @@ extension OELibraryDatabase {
     
     func downloadMissingArtwork() {
         let alert = OEAlert()
-        alert.messageText = NSLocalizedString("While performing this operation OpenEmu will be unresponsive.", tableName: "Debug", comment: "")
+        alert.messageText = Bundle.main.preferredLocalizedString(forKey: "While performing this operation OpenEmu will be unresponsive.", value: "No translation", table: "Debug")
         alert.defaultButtonTitle = NSLocalizedString("Continue", comment: "")
         alert.alternateButtonTitle = NSLocalizedString("Cancel", comment: "")
         if alert.runModal() != .alertFirstButtonReturn {

--- a/OpenEmu/PluginDocument.swift
+++ b/OpenEmu/PluginDocument.swift
@@ -30,9 +30,9 @@ extension OEGameCorePluginError: LocalizedError {
     public var failureReason: String? {
         switch self {
         case .alreadyLoaded:
-            return NSLocalizedString("ERROR_PLUGIN_IMPORT_ALREADYLOADED", comment: "Error, another version of imported plugin is already loaded")
+            return Bundle.main.preferredLocalizedString(forKey: "ERROR_PLUGIN_IMPORT_ALREADYLOADED", value: "No translation", table: nil) // Error, another version of imported plugin is already loaded
         case .outOfSupport:
-            return NSLocalizedString("ERROR_PLUGIN_IMPORT_OUTOFSUPPORT", comment: "Error, plugin to be imported is out of support")
+            return Bundle.main.preferredLocalizedString(forKey: "ERROR_PLUGIN_IMPORT_OUTOFSUPPORT", value: "No translation", table: nil) // Error, plugin to be imported is out of support
         case .invalid:
             return nil
         }

--- a/OpenEmu/PrefDebugController.swift
+++ b/OpenEmu/PrefDebugController.swift
@@ -77,8 +77,8 @@ final class PrefDebugController: NSViewController {
         Checkbox(key: OEPopoutGameWindowTreatScaleFactorAsPixels, label: "Change scale menu unit from points to pixels"),
         Checkbox(key: OEAdaptiveSyncEnabledKey, label: "Enable adaptive sync for supported displays (full screen)"),
         Popover(key: OEAppearance.HUDBar.key, label: "Appearance:", action: #selector(changeHUDBarAppearance(_:)), options: [
-            Option(label: "Vibrant", value: OEAppearance.HUDBar.vibrant.rawValue),
-            Option(label: "Dark", value: OEAppearance.HUDBar.dark.rawValue),
+            Option(label: "Vibrant (HUD)", value: OEAppearance.HUDBar.vibrant.rawValue),
+            Option(label: "Dark (HUD)", value: OEAppearance.HUDBar.dark.rawValue),
         ]),
         ColorWell(key: OEPopoutGameWindowBackgroundColorKey, label: "Game View Background color:"),
         
@@ -91,9 +91,9 @@ final class PrefDebugController: NSViewController {
         Checkbox(key: "logsHIDEventsNoKeyboard", label: "Log Keyboard Events"),
         Checkbox(key: OEPrefControlsShowAllGlobalKeys, label: "Show all special keys"),
         Popover(key: OEAppearance.ControlsPrefs.key, label: "Appearance:", action: #selector(changeControlsPrefsAppearance(_:)), options: [
-            Option(label: "Wood", value: OEAppearance.ControlsPrefs.wood.rawValue),
-            Option(label: "Vibrant", value: OEAppearance.ControlsPrefs.vibrant.rawValue),
-            Option(label: "Vibrant Wood", value: OEAppearance.ControlsPrefs.woodVibrant.rawValue),
+            Option(label: "Wood (Controls)", value: OEAppearance.ControlsPrefs.wood.rawValue),
+            Option(label: "Vibrant (Controls)", value: OEAppearance.ControlsPrefs.vibrant.rawValue),
+            Option(label: "Vibrant Wood (Controls)", value: OEAppearance.ControlsPrefs.woodVibrant.rawValue),
         ]),
         NumericTextField(key: "OESystemResponderADCThreshold", label: "Threshold for analog controls bound to buttons:", numberFormatter: NumericTextField.NF(allowsFloats: true, minimum: 0.01, maximum: 0.99, numberStyle: .decimal)),
         
@@ -127,7 +127,7 @@ final class PrefDebugController: NSViewController {
         Button(label: "Cleanup rom hashes", action: #selector(cleanupHashes(_:))),
         Button(label: "Remove duplicated roms", action: #selector(removeDuplicatedRoms(_:))),
         Button(label: "Cancel cover sync for all games", action: #selector(cancelCoverArtSync(_:))),
-        Label(label: ""),
+        Padding(),
         Button(label: "Perform Sanity Check on Database", action: #selector(sanityCheck(_:))),
     ]
     
@@ -173,7 +173,7 @@ final class PrefDebugController: NSViewController {
         let defaultDefaults = UserDefaults.standard.volatileDomain(forName: UserDefaults.registrationDomain)
         
         if let item = item as? Checkbox {
-            let label = NSLocalizedString(item.label, tableName: "Debug", comment: "")
+            let label = Bundle.main.preferredLocalizedString(forKey: item.label, value: "No translation", table: "Debug")
             let key = item.key
             let negated = item.negated
             
@@ -189,10 +189,10 @@ final class PrefDebugController: NSViewController {
             
             if let originalValue = defaultDefaults[key] as? NSNumber {
                 let origbool = originalValue.boolValue != negated
-                let fmt = NSLocalizedString("Default Value: %@", tableName: "Debug", comment: "Default value tooltip format in the Debug Preferences")
+                let fmt = Bundle.main.preferredLocalizedString(forKey: "Default Value: %@", value: "No translation", table: "Debug") // Default value tooltip format in the Debug Preferences
                 let val = origbool
-                    ? NSLocalizedString("Checked", tableName: "Debug", comment: "Default value tooltip for checkboxes: checked default")
-                    : NSLocalizedString("Unchecked", tableName: "Debug", comment: "Default value tooltip for checkboxes: unchecked default")
+                    ? Bundle.main.preferredLocalizedString(forKey: "Checked", value: "No translation", table: "Debug") // Default value tooltip for checkboxes: checked default
+                    : Bundle.main.preferredLocalizedString(forKey: "Unchecked", value: "No translation", table: "Debug") // Default value tooltip for checkboxes: unchecked default
                 
                 checkbox.toolTip = String(format: fmt, val)
             }
@@ -200,7 +200,7 @@ final class PrefDebugController: NSViewController {
             gridView.addRow(with: [NSGridCell.emptyContentView, checkbox])
         }
         else if let item = item as? ColorWell {
-            let label = NSLocalizedString(item.label, tableName: "Debug", comment: "")
+            let label = Bundle.main.preferredLocalizedString(forKey: item.label, value: "No translation", table: "Debug")
             let key = item.key
             
             let labelField = NSTextField(labelWithString: label)
@@ -237,7 +237,7 @@ final class PrefDebugController: NSViewController {
             ])
         }
         else if let item = item as? Group {
-            let label = NSLocalizedString(item.label, tableName: "Debug", comment: "")
+            let label = Bundle.main.preferredLocalizedString(forKey: item.label, value: "No translation", table: "Debug")
             
             let field = NSTextField(labelWithString: label)
             field.font = NSFont.boldSystemFont(ofSize: 0)
@@ -246,14 +246,14 @@ final class PrefDebugController: NSViewController {
             row.bottomPadding = 4
         }
         else if let item = item as? Label {
-            let label = NSLocalizedString(item.label, tableName: "Debug", comment: "")
+            let label = Bundle.main.preferredLocalizedString(forKey: item.label, value: "No translation", table: "Debug")
             
             let labelField = NSTextField(labelWithString: label)
             
             gridView.addRow(with: [NSGridCell.emptyContentView, labelField])
         }
         else if let item = item as? Button {
-            let label = NSLocalizedString(item.label, tableName: "Debug", comment: "")
+            let label = Bundle.main.preferredLocalizedString(forKey: item.label, value: "No translation", table: "Debug")
             let action = item.action
             
             let button = NSButton(title: label, target: self, action: action)
@@ -261,7 +261,7 @@ final class PrefDebugController: NSViewController {
             gridView.addRow(with: [NSGridCell.emptyContentView, button])
         }
         else if let item = item as? Popover {
-            let label = NSLocalizedString(item.label, tableName: "Debug", comment: "")
+            let label = Bundle.main.preferredLocalizedString(forKey: item.label, value: "No translation", table: "Debug")
             let options = item.options
             let action = item.action
             
@@ -275,7 +275,7 @@ final class PrefDebugController: NSViewController {
             let menu = NSMenu()
             for option in options {
                 let item = NSMenuItem()
-                item.title = NSLocalizedString(option.label, tableName: "Debug", comment: "")
+                item.title = Bundle.main.preferredLocalizedString(forKey: option.label, value: "No translation", table: "Debug")
                 item.representedObject = option.value
                 menu.addItem(item)
             }
@@ -287,7 +287,7 @@ final class PrefDebugController: NSViewController {
             gridView.addRow(with: [labelField, popup])
         }
         else if let item = item as? NumericTextField {
-            let label = NSLocalizedString(item.label, tableName: "Debug", comment: "")
+            let label = Bundle.main.preferredLocalizedString(forKey: item.label, value: "No translation", table: "Debug")
             let nf = item.numberFormatter
             let key = item.key
             
@@ -304,13 +304,13 @@ final class PrefDebugController: NSViewController {
             inputField.formatter = numberFormatter
             inputField.bind(.value, to: NSUserDefaultsController.shared, withKeyPath: "values.\(key)", options: nil)
             
-            let validRangeFormat = NSLocalizedString("Range: %@ to %@", tableName: "Debug", comment: "Range indicator tooltip for numeric text boxes in the Debug Preferences")
+            let validRangeFormat = Bundle.main.preferredLocalizedString(forKey: "Range: %@ to %@", value: "No translation", table: "Debug") // Range indicator tooltip for numeric text boxes in the Debug Preferences
             let min = numberFormatter.string(from: nf.minimum) ?? ""
             let max = numberFormatter.string(from: nf.maximum) ?? ""
             var tooltip = String(format: validRangeFormat, min, max)
             
             if let defaultv = defaultDefaults[key] as? NSNumber {
-                let fmt = NSLocalizedString("Default Value: %@", tableName: "Debug", comment: "Default value tooltip format in the Debug Preferences")
+                let fmt = Bundle.main.preferredLocalizedString(forKey: "Default Value: %@", value: "No translation", table: "Debug") // Default value tooltip format in the Debug Preferences
                 let defaultstr = numberFormatter.string(from: defaultv) ?? ""
                 tooltip += "\n" + String(format: fmt, defaultstr)
             }
@@ -318,6 +318,14 @@ final class PrefDebugController: NSViewController {
             
             gridView.addRow(with: [labelField, inputField])
             inputField.widthAnchor.constraint(equalToConstant: 70).isActive = true
+        }
+        else if item is Padding {
+            let padding = NSBox()
+            padding.isTransparent = true
+            
+            let row = gridView.addRow(with: [NSGridCell.emptyContentView, padding])
+            row.topPadding = -6
+            row.bottomPadding = -6
         }
         else if item is Separator {
             let separator = NSBox()
@@ -546,6 +554,8 @@ final class PrefDebugController: NSViewController {
 private extension PrefDebugController {
     
     struct Separator {
+    }
+    struct Padding {
     }
     struct Group {
         let label: String

--- a/OpenEmu/PrefLibraryController.swift
+++ b/OpenEmu/PrefLibraryController.swift
@@ -75,8 +75,7 @@ final class PrefLibraryController: NSViewController {
         alert.messageText = NSLocalizedString(
             "Moving the Game Library is not recommended",
             comment: "Message headline (attempted to change location of library)")
-        alert.informativeText = NSLocalizedString("ALERT_MOVE_LIBRARY_HTML",
-            comment: "Message text (attempted to change location of library, HTML)")
+        alert.informativeText = Bundle.main.preferredLocalizedString(forKey: "ALERT_MOVE_LIBRARY_HTML", value: "No translation", table: nil) // Message text (attempted to change location of library, HTML)
         alert.defaultButtonTitle = NSLocalizedString("Cancel", comment: "")
         alert.alternateButtonTitle = NSLocalizedString("I understand the risks",
             comment: "OK button (attempted to change location of library)")

--- a/OpenEmu/ScreenshotViewController.swift
+++ b/OpenEmu/ScreenshotViewController.swift
@@ -75,7 +75,7 @@ extension ScreenshotViewController: CollectionViewExtendedDelegate, NSMenuItemVa
         let menu = NSMenu()
         
         if #available(macOS 13.0, *) {
-            let share = menu.addItem(withTitle: NSLocalizedString("SHARE_STANDARD_MENU_ITEM_TITLE", comment: "Share menu item, see Finder or ShareKit.loctable"),
+            let share = menu.addItem(withTitle: Bundle.main.preferredLocalizedString(forKey: "SHARE_STANDARD_MENU_ITEM_TITLE", value: "No translation", table: nil), // Share menu item, see Finder or ShareKit.loctable
                                      action: #selector(showSharingServicePicker(_:)),
                                      keyEquivalent: "")
             share.representedObject = collectionView.indexPathForItem(at: point)

--- a/OpenEmu/ShaderParametersViewController.swift
+++ b/OpenEmu/ShaderParametersViewController.swift
@@ -284,7 +284,7 @@ extension ShaderParametersViewController: NSToolbarDelegate {
             tbi.visibilityPriority = .low
             tbi.view = shaderListPopUpButton
             let mi = NSMenuItem()
-            mi.title = NSLocalizedString("Select Shader", comment: "Menu: Show a list of shaders the user may choose from")
+            mi.title = Bundle.main.preferredLocalizedString(forKey: "Select Shader", value: "No translation", table: nil) // Menu: Show a list of shaders the user may choose from
             mi.submenu = shaderListPopUpButton.menu
             tbi.menuFormRepresentation = mi
             return tbi

--- a/OpenEmu/SidebarController.swift
+++ b/OpenEmu/SidebarController.swift
@@ -410,7 +410,7 @@ extension SidebarController: NSOutlineViewDataSource {
                 
                 switch group.autosaveName {
                 case .sidebarConsolesItem:
-                    button.title = NSLocalizedString("Edit", tableName: "OEControls", comment: "")
+                    button.title = Bundle.main.preferredLocalizedString(forKey: "Edit", value: "No translation", table: "OEControls")
                     button.image = nil
                     button.action = #selector(selectSystems(_:))
                 case .sidebarCollectionsItem:
@@ -615,7 +615,7 @@ extension SidebarController: NSMenuDelegate {
             }
             
             menuItem = NSMenuItem()
-            menuItem.title = .localizedStringWithFormat(NSLocalizedString("Hide \"%@\"", comment: ""), item.name)
+            menuItem.title = .localizedStringWithFormat(Bundle.main.preferredLocalizedString(forKey: "Hide \"%@\"", value: "No translation", table: nil), item.name)
             menuItem.action = #selector(toggleSystem(for:))
             menuItem.representedObject = item
             menu.addItem(menuItem)
@@ -625,7 +625,7 @@ extension SidebarController: NSMenuDelegate {
             if item.isEditableInSidebar {
                 
                 menuItem = NSMenuItem()
-                menuItem.title = .localizedStringWithFormat(NSLocalizedString("Rename \"%@\"", comment: "Rename collection sidebar context menu item"), item.sidebarName)
+                menuItem.title = .localizedStringWithFormat(Bundle.main.preferredLocalizedString(forKey: "Rename \"%@\"", value: "No translation", table: nil), item.sidebarName) // Rename collection sidebar context menu item
                 menuItem.action = #selector(renameItem(for:))
                 menuItem.tag = index
                 menu.addItem(menuItem)

--- a/OpenEmu/en.lproj/Debug.strings
+++ b/OpenEmu/en.lproj/Debug.strings
@@ -122,3 +122,25 @@
 "Dark (default)" = "Dark (default)";
 
 "Light" = "Light";
+
+"Use new save states view" = "Use new save states view";
+
+"Use new screenshots view" = "Use new screenshots view";
+
+"Change scale menu unit from points to pixels" = "Change scale menu unit from points to pixels";
+
+"Enable adaptive sync for supported displays (full screen)" = "Enable adaptive sync for supported displays (full screen)";
+
+"Vibrant (HUD)" = "Vibrant";
+
+"Dark (HUD)" = "Dark";
+
+"Wood (Controls)" = "Wood";
+
+"Vibrant (Controls)" = "Vibrant";
+
+"Vibrant Wood (Controls)" = "Vibrant Wood";
+
+"Save States" = "Save States";
+
+"Download additional shaders" = "Download additional shaders";


### PR DESCRIPTION
3 out of the 6 localization tables (Localizable, ControlLabels, and Debug) (and a few entries from OEControls and MainMenu) do not localize correctly for regional language variants (eg: English (UK)).

(eg: "ALERT_INPUT_MONITORING_HEADLINE" (from Localizable) localizes to "OpenEmu requires additional permissions" in English, but is not listed in English (UK) - the code will fail to localize because only the first language (English (UK)) is looked up (rather than English (UK), then English).) (#4954, #5070, #4991)

(For most entries this isn't a problem, since the localization key (eg: "Add to Collection") usually matches the localization (also "Add to Collection"), so when the localization fails, the key is rendered instead, and it's still correct.)


- The fix is for the Debug and ControlLabels localization tables (and a few entries from OEControls and MainMenu) to support regional language variants (using Bundle.localizedString), for consistency with the OEControls and MainMenu tables. (Also included are entries from the Localizable table, where the key doesn't match the localization.) (The change means that localizations from these tables/entries can no longer be generated from the code.)

- Strings missing from the Debug localization table have been added (for English only).