### PR TITLE
Controls UI fixes for building with macOS 26 SDK

### DIFF
--- a/OpenEmu/ControlsPopUpButton.swift
+++ b/OpenEmu/ControlsPopUpButton.swift
@@ -31,6 +31,13 @@ final class ControlsPopUpButton: NSPopUpButton {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
+        // Use right-to-left alignment for RTL languages, for SDKs 26.0 and above
+        #if canImport(AppKit, _version: 2665.8)
+            if (NSParagraphStyle.defaultWritingDirection(forLanguage: nil) == NSWritingDirection.rightToLeft) {
+                userInterfaceLayoutDirection = .rightToLeft
+            }
+        #endif
+        
         frame.size.height = 23
         cachedIntrinsicWidth = -1
     }

--- a/OpenEmu/ControlsPopUpButtonCell.swift
+++ b/OpenEmu/ControlsPopUpButtonCell.swift
@@ -26,6 +26,13 @@ import Cocoa
 
 final class ControlsPopUpButtonCell: NSPopUpButtonCell {
     
+    private var imagePadding: CGFloat = 4
+    private var titleLeftPadding: CGFloat = 11
+    
+    // Used for right-to-left languages
+    private var titleRightPadding: CGFloat = 4
+    private var arrowWidth: CGFloat = 16
+    
     override func drawBorderAndBackground(withFrame cellFrame: NSRect, in controlView: NSView) {
         NSImage(named: "wood_popup_button")?.draw(in: cellFrame)
     }
@@ -35,31 +42,70 @@ final class ControlsPopUpButtonCell: NSPopUpButtonCell {
     }
     
     override func titleRect(forBounds cellFrame: NSRect) -> NSRect {
-        if #available(macOS 11.0, *) {
-            return super.titleRect(forBounds: cellFrame)
-        }
         var titleRect = super.titleRect(forBounds: cellFrame)
-        titleRect.origin.y += 1
+        let imageRect = imageRect(forBounds: cellFrame)
+        
+        if #available(macOS 11.0, *) {
+            #if canImport(AppKit, _version: 2665.8)     // Fix the title for SDKs 26.0 and above
+                titleRect.origin.y -= 0.5
+
+                let titleWidth = titleRect.width
+                let hasImage = !imageRect.isEmpty
+                let imageWidth = imageRect.size.width
+                if (userInterfaceLayoutDirection == .rightToLeft) {
+                    titleRect.origin.x = cellFrame.maxX - arrowWidth - titleRightPadding - titleWidth
+                    
+                    if (hasImage) {
+                        titleRect.origin.x -= (imageWidth + imagePadding)
+                    }
+                } else {
+                    titleRect.origin.x = cellFrame.minX + titleLeftPadding
+                    
+                    if (hasImage) {
+                        titleRect.origin.x += imageWidth + imagePadding
+                    }
+                }
+            
+                if (titleRect.origin.x < titleLeftPadding) {
+                    titleRect.origin.x = titleLeftPadding
+                }
+            #else
+                titleRect.origin.y -= 3
+            #endif
+        } else {
+            titleRect.origin.y -= 2
+        }
+        
         return titleRect
     }
     
     override func imageRect(forBounds rect: NSRect) -> NSRect {
         if #available(macOS 11.0, *) {
             var imageRect = super.imageRect(forBounds: rect)
-            imageRect.origin.y -= 1
+            
+            #if canImport(AppKit, _version: 2665.8)    // Fix the image placement for SDKs 26.0 and above
+                imageRect.origin.y += 0.5
+            
+                if (userInterfaceLayoutDirection == .rightToLeft) {
+                    imageRect.origin.x -= 7
+                }
+                imageRect.origin.x -= 1
+            #else
+                imageRect.origin.y -= 1
+            #endif
+            
             return imageRect
         }
         return super.imageRect(forBounds: rect)
     }
     
     override func drawInterior(withFrame cellFrame: NSRect, in controlView: NSView) {
-        var titleRect = titleRect(forBounds: cellFrame)
+        let titleRect = titleRect(forBounds: cellFrame)
         let imageRect = imageRect(forBounds: cellFrame)
         
-        if !titleRect.isEmpty {
-            titleRect.origin.y -= 3
-            let attributedTitle = NSAttributedString(string: title, attributes: Self.attributes)
-            drawTitle(attributedTitle, withFrame: titleRect, in: controlView)
+        if !titleRect.isEmpty,
+            let title = title {
+            title.draw(in: titleRect, withAttributes: Self.attributes)
         }
         if !imageRect.isEmpty,
            let image = image {


### PR DESCRIPTION
When building with the macOS 26 SDK, the Pop-up Buttons in Settings > Controls do not draw correctly. (The text draws without a shadow and doesn't align correctly for right-to-left languages, and the image and text are placed incorrectly.)

The fixes for the NSPopUpButtons are:
- NSButtonCell.drawTitle(_:withFrame:in:) causes drawing issues (it should no longer be called directly), so NSString.draw(in:withAttributes:) is used instead.
- Set userInterfaceLayoutDirection to align the text (and image) properly for right-to-left languages (eg: Arabic).
- Placement fixes for the text and image when building with the macOS 26 SDK. When using a RTL language (eg: Arabic), the text is now placed a bit closer to the right control edge (see images), for more consistency with left-to-right languages.

Building with macOS 26 SDK, before fixes:
<img width="867" height="650" alt="Screenshot 2026-04-08 at 12 05 14 pm" src="https://github.com/user-attachments/assets/08123863-ed6c-408b-9e74-19f96b9f4ecf" />
<img width="867" height="650" alt="‏لقطة الشاشة 2026-04-08 في 12 06 49 م" src="https://github.com/user-attachments/assets/ed377d18-474a-418a-bd14-bcb6336c7719" />

After fixes:
<img width="867" height="650" alt="Screenshot 2026-04-09 at 7 11 40 am" src="https://github.com/user-attachments/assets/03d98e42-3e9a-4caf-a777-076825b5d583" />
<img width="867" height="650" alt="‏لقطة الشاشة 2026-04-09 في 7 12 25 ص" src="https://github.com/user-attachments/assets/5016a0a5-d946-49ec-a625-0af220678e4d" />

OpenEmu 2.4.1:
<img width="867" height="642" alt="Screenshot 2026-04-09 at 7 05 16 am" src="https://github.com/user-attachments/assets/72ce6482-1873-4c84-8e90-86fe7f50271e" />
<img width="867" height="642" alt="‏لقطة الشاشة 2026-04-09 في 7 04 37 ص" src="https://github.com/user-attachments/assets/5f7dde9e-88cc-4328-8334-07cb05ce5abe" />
