### PR TITLE
Library UI fix for building with macOS 26 SDK

### DIFF
--- a/OpenEmu/AvailableLibrariesViewController.swift
+++ b/OpenEmu/AvailableLibrariesViewController.swift
@@ -84,6 +84,7 @@ final class AvailableLibrariesViewController: NSViewController {
     }
     
     override func viewWillAppear() {
+        super.viewWillAppear()
         loadData()
     }
     

--- a/OpenEmu/PreferencesWindowController.swift
+++ b/OpenEmu/PreferencesWindowController.swift
@@ -58,8 +58,11 @@ final class PreferencesWindowController: NSWindowController {
         
         super.windowDidLoad()
         
+        let frameSize = self.window?.contentView?.frame.size ?? .zero
+        
         preferencesTabViewController = PreferencesTabViewController()
-        self.window?.contentView = preferencesTabViewController.view
+        self.window?.contentViewController = preferencesTabViewController
+        self.window?.setContentSize(frameSize)          // Reset size to load value
         
         if #available(macOS 11.0, *) {
             window?.toolbarStyle = .preference


### PR DESCRIPTION
When building with the macOS 26 SDK, if the Library tab in Settings is selected, Settings > Library will show with a blank Available Libraries list (for the first show of Settings per launch only).

The issue is that the Available Libraries NSCollectionView will not reloadData() during AvailableLibrariesViewController.viewWillAppear(), if the window is not visible.

The fix is:
- set the Preferences window.contentViewController during the NSWindowController loading, so that the view is managed (such that reloadData() will succeed)
- manage the change in window size after setting contentViewController, so that the size is set back to the load value (from Preferences.xib)

Building with macOS 26 SDK, before fix:
<img width="731" height="562" alt="Screenshot 2026-04-18 at 11 18 45 am" src="https://github.com/user-attachments/assets/85d93eed-b7ec-4c8e-85ee-f91ddef08f20" />
